### PR TITLE
Add ability to check if existing DEPENDENCIES file is up-to-date

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,5 @@ RUN git clone https://github.com/eclipse/dash-licenses.git && \
 
 COPY ${PWD}/src/bump-deps.js bump-deps.js
 COPY ${PWD}/src/entrypoint.sh entrypoint.sh
-COPY ${PWD}/src/entrypoint-check.sh entrypoint-check.sh
 
 ENTRYPOINT ["/workspace/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,15 +36,17 @@ ENV PATH=/usr/local/lib/nodejs/node-${NODE_VERSION}-${NODE_DISTRO}/bin/:$PATH
 
 RUN npm install yarn -g
 
-RUN mkdir /workspace && cd /workspace && \
-    git clone https://github.com/eclipse/dash-licenses.git && \
-    cd /workspace/dash-licenses && git checkout ${DASH_LICENT_REV} && \
-    mvn clean install && \
-    cd ./yarn && yarn install
+WORKDIR /workspace
+RUN git clone https://github.com/eclipse/dash-licenses.git && \
+  cd dash-licenses && \
+  git checkout ${DASH_LICENSE_REV} && \
+  mvn clean install && \
+  cp core/target/org.eclipse.dash.licenses-0.0.1-SNAPSHOT.jar /workspace/dash-licenses.jar && \
+  cd yarn && \
+  yarn install 
 
-WORKDIR /workspace/
-
-ADD ${PWD}/src/entrypoint.sh /workspace/entrypoint.sh
-ADD ${PWD}/src/bump-deps.js /workspace/bump-deps.js
+COPY ${PWD}/src/bump-deps.js bump-deps.js
+COPY ${PWD}/src/entrypoint.sh entrypoint.sh
+COPY ${PWD}/src/entrypoint-check.sh entrypoint-check.sh
 
 ENTRYPOINT ["/workspace/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,3 +49,4 @@ COPY ${PWD}/src/bump-deps.js bump-deps.js
 COPY ${PWD}/src/entrypoint.sh entrypoint.sh
 
 ENTRYPOINT ["/workspace/entrypoint.sh"]
+CMD ["--generate"]

--- a/README.md
+++ b/README.md
@@ -1,20 +1,29 @@
 # Container wrapper for Eclipse Dash License Tool
 
-It's container wrapper for (The Eclipse Dash License Tool)[https://github.com/eclipse/dash-licenses] that allows easily to generate dependencies files with container image without need to compile dash-licenses jar.
+This is a container wrapper for [The Eclipse Dash License Tool](https://github.com/eclipse/dash-licenses) that allows easily to generate dependencies files with container image without the need to compile `dash-licenses` jar.
 
 ## Requirements
 
 - Docker
 
-## Running
-To generate dependencies info:
+## Build
+
+```sh
+./build.sh
+```
+
+## Usage
+
+The following command generates dependencies info of a project and then checks all found dependencies. It returns a non-zero exit code if any of them are restricted to use.
+
 ```sh
 docker run --rm -t \
        -v ${PWD}/:/workspace/project  \
        quay.io/che-incubator/dash-licenses:next
 ```
 
-To generate dependencies info and fail if any dependency present which does not satisfies license requirements:
+This command doesn't create any new files in the project directory (except a temporary one) but checks if dependencies info is up-to-date and then validates all found dependencies. It returns a non-zero exit code if any of the dependencies are restricted to use. 
+
 ```sh
 docker run --rm -t \
        -v ${PWD}/:/workspace/project  \

--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ It's container wrapper for (The Eclipse Dash License Tool)[https://github.com/ec
 
 - Docker
 
-## Quick start
-
+## Running
+To generate dependencies info:
 ```sh
-$ ./build.sh
+docker run --rm -t \
+       -v ${PWD}/:/workspace/project  \
+       quay.io/che-incubator/dash-licenses:next
 ```
 
-## Running
+To generate dependencies info and fail if any dependency present which does not satisfies license requirements:
 ```sh
-docker run --rm -t -v ${PWD}/yarn.lock:/workspace/yarn.lock  \
-       -v ${PWD}/package.json:/workspace/package.json  \
-       -v ${PWD}/.deps:/workspace/.deps  \
-       -v ${PWD}/.deps/tmp/DEPENDENCIES:/workspace/DEPENDENCIES \
-       quay.io/che-incubator/che-dashboard-next:nodejs-license-tool
+docker run --rm -t \
+       -v ${PWD}/:/workspace/project  \
+       quay.io/che-incubator/dash-licenses:next --check
 ```

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
+# Simple script that helps to build local version to test easily
 set -e
 set -u
 
-docker build -f Dockerfile -t quay.io/che-incubator/che-dashboard-next:nodejs-license-tool .
+docker build -f Dockerfile -t quay.io/che-incubator/dash-licenses:local .

--- a/src/entrypoint-check.sh
+++ b/src/entrypoint-check.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./entrypoint.sh --check

--- a/src/entrypoint-check.sh
+++ b/src/entrypoint-check.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-./entrypoint.sh --check

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -1,20 +1,77 @@
 #!/bin/bash
 
-if [ ! -f yarn.lock ]; then
-    echo "Can't find yarn.lock. Generate lock file and try again."
+CHECK=""
+if [ "$1" = "--check" ]; then
+    CHECK="$1";
+fi
+
+WORKSPACE=$(pwd)
+PROJECT=$WORKSPACE/project
+
+if [ ! -d $PROJECT ]; then
+    echo
+    echo "Error: The project directory is not mounted."
     exit 1
 fi
 
-DASH_LICENSES=dash-licenses/core/target/org.eclipse.dash.licenses-0.0.1-SNAPSHOT.jar
+if [ ! -f $PROJECT/package.json ]; then
+    echo "Error: Can't find package.json file in the project directory. Commit it and then try again."
+    exit 1
+fi
+
+if [ ! -f $PROJECT/yarn.lock ]; then
+    echo "Error: Can't find yarn.lock file. Generate and commit the lock file and then try again."
+    exit 1
+fi
+
+if [ -n "$CHECK" ] && [ ! -f $PROJECT/DEPENDENCIES ]; then
+    echo "Error: Can't find DEPENDENCIES file. Generate and commit this file for the project using 'dash-license' and then try again."
+    exit 1
+fi
+
+DASH_LICENSES_DIR=$WORKSPACE/dash-licenses
+DASH_LICENSES=$WORKSPACE/dash-licenses.jar
 if [ ! -f $DASH_LICENSES ]; then
-    echo "Can't find org.eclipse.dash.licenses-0.0.1-SNAPSHOT.jar. Rebuild 'nodejs-license-tool' image and try again."
+    echo "Error: Can't find dash-licenses.jar. Rebuild 'nodejs-license-tool' image and try again."
     exit 1
 fi
 
-echo "The DEPENDENCIES file is being generated..."
-node dash-licenses/yarn/index.js | java -jar $DASH_LICENSES -summary DEPENDENCIES -
-echo "Done."
+cd $PROJECT
 
-echo "The dev.md and prod.md files are being generated..."
-node ./bump-deps.js
+echo "The temporary DEPENDENCIES file is being generated..."
+node $DASH_LICENSES_DIR/yarn/index.js | java -jar $DASH_LICENSES -summary $PROJECT/TMP_DEPENDENCIES - > /dev/null
 echo "Done."
+echo
+
+DIFFER=""
+
+if [ -n "$CHECK" ]; then
+    echo "Comparing temporary DEPENDENCIES file with committed one..."
+    DIFFER=$(comm --nocheck-order -3 $PROJECT/DEPENDENCIES $PROJECT/TMP_DEPENDENCIES)
+    echo "Done."
+    echo
+fi
+
+echo "Checking licenses for restrictions to use..."
+node $WORKSPACE/bump-deps.js $CHECK
+RESTRICTED=$?
+echo "Done."
+echo
+
+if [ -n "$CHECK" ]; then
+    rm $PROJECT/TMP_DEPENDENCIES
+else
+    mv $PROJECT/TMP_DEPENDENCIES $PROJECT/DEPENDENCIES
+fi
+
+if [ -n "$DIFFER" ]; then
+    echo "Error: The generated dependencies list differs from one in the project. Please regenerate and commit DEPENDENCIES file."
+fi
+if [ $RESTRICTED -ne 0 ]; then
+    echo "Error: Restricted dependencies are found in the project."
+fi
+if [ -z "$DIFFER" ] && [ $RESTRICTED -eq 0 ]; then
+    echo "All found licenses are approved to use."
+else
+    exit 1;
+fi

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+if [ "$1" = "--help" ]; then
+    cat << EOF
+Usage: entrypoint supports the following arguments [ARGS]
+Arguments:
+  --check
+      In addition to generate dependencies info, check if all of them suttisfy
+      License requirements, fail if no
+  --help
+      Print this message
+EOF
+    exit 0
+fi
+
 CHECK=""
 if [ "$1" = "--check" ]; then
     CHECK="$1";

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -17,10 +17,18 @@ EOM
     exit 0
 }
 
+build_info_msg() {
+    cat <<EOM
+docker run \\
+    -v \$(pwd):/workspace/project \\
+    quay.io/che-incubator/dash-licenses:next
+EOM
+}
+
 if [ "$1" = "--help" ]; then
     usage
 fi
-if [ "$1" != "--help" ] && [ "$1" != "--check" ] && [ "$1" != "--generate" ]; then
+if [ "$1" != "--help" ] && [ "$1" != "--check" ] && [ "$1" != "--generate" ] && [ "$1" != "--debug" ]; then
     echo "Error: unknown argument \"$1\" for \"$0\""
     echo "Run with argument \"--help\" for usage."
     exit 0
@@ -31,80 +39,109 @@ if [ "$1" = "--check" ]; then
     CHECK="$1"
 fi
 
-WORKSPACE=$(pwd)
-PROJECT=$WORKSPACE/project
+DEBUG=""
+if [ "$1" = "--debug" ]; then
+    DEBUG="$1"
+fi
 
-if [ ! -d $PROJECT ]; then
+WORKSPACE_DIR=$(pwd)
+PROJECT_DIR=$WORKSPACE_DIR/project
+DEPS_DIR=$PROJECT_DIR/.deps
+TMP_DIR=$DEPS_DIR/tmp
+CACHE_DIR=$TMP_DIR/cache
+
+mkdir -p $CACHE_DIR
+
+if [ ! -d $PROJECT_DIR ]; then
     echo
     echo "Error: The project directory is not mounted."
     exit 1
 fi
 
-if [ ! -f $PROJECT/package.json ]; then
+echo $PROJECT_DIR
+if [ ! -f $PROJECT_DIR/package.json ]; then
     echo "Error: Can't find package.json file in the project directory. Commit it and then try again."
     exit 1
 fi
 
-if [ ! -f $PROJECT/yarn.lock ]; then
+if [ ! -f $PROJECT_DIR/yarn.lock ]; then
     echo "Error: Can't find yarn.lock file. Generate and commit the lock file and then try again."
     exit 1
 fi
 
-if [ -n "$CHECK" ] && [ ! -f $PROJECT/DEPENDENCIES ]; then
-    # echo "Error: Can't find DEPENDENCIES file. Generate and commit this file for the project using 'dash-license' and then try again."
-    cat <<EOM
-Error: Can't find DEPENDENCIES file.
-Execute the following command to generate dependencies info and then try again:
-
-docker run \\
-       -v \$(pwd):/workspace/project \\
-       quay.io/che-incubator/dash-licenses:next
-EOM
-    exit 1
-fi
-
-DASH_LICENSES_DIR=$WORKSPACE/dash-licenses
-DASH_LICENSES=$WORKSPACE/dash-licenses.jar
+DASH_LICENSES_DIR=$WORKSPACE_DIR/dash-licenses
+DASH_LICENSES=$WORKSPACE_DIR/dash-licenses.jar
 if [ ! -f $DASH_LICENSES ]; then
     echo "Error: Can't find dash-licenses.jar. Contact https://github.com/che-incubator/dash-licenses maintainers to fix the issue."
     exit 1
 fi
 
-cd $PROJECT
+cd $PROJECT_DIR
 
-echo "The temporary DEPENDENCIES file is being generated..."
-node $DASH_LICENSES_DIR/yarn/index.js | java -jar $DASH_LICENSES -summary $PROJECT/TMP_DEPENDENCIES - > /dev/null
+echo "Generating a temporary DEPENDENCIES file..."
+node $DASH_LICENSES_DIR/yarn/index.js | java -jar $DASH_LICENSES -summary $TMP_DIR/DEPENDENCIES - > /dev/null
 echo "Done."
 echo
 
-DIFFER=""
+echo "Generating all dependencies info using yarn..."
+yarn licenses list --json --depth=0 --no-progres --prefer-offline --frozen-lockfile > $TMP_DIR/yarn-deps-info.json
+echo "Done."
+echo
 
-if [ -n "$CHECK" ]; then
-    echo "Comparing temporary DEPENDENCIES file with committed one..."
-    DIFFER=$(comm --nocheck-order -3 $PROJECT/DEPENDENCIES $PROJECT/TMP_DEPENDENCIES)
-    echo "Done."
-    echo
-fi
+echo "Generating list of production dependencies using yarn..."
+yarn list --json --prod --depth=0 --no-progres > $TMP_DIR/yarn-prod-deps.json
+echo "Done."
+echo
 
-echo "Checking licenses for restrictions to use..."
-node $WORKSPACE/bump-deps.js $CHECK
+echo "Generating list of all dependencies using yarn..."
+yarn list --json --depth=0 --no-progress > $TMP_DIR/yarn-all-deps.json
+echo "Done."
+echo
+
+echo "Checking dependencies for restrictions to use..."
+node $WORKSPACE_DIR/bump-deps.js $CHECK
 RESTRICTED=$?
 echo "Done."
 echo
 
+DIFFER_PROD=""
+DIFFER_DEV=""
+
+# production dependencies
 if [ -n "$CHECK" ]; then
-    rm $PROJECT/TMP_DEPENDENCIES
-else
-    mv $PROJECT/TMP_DEPENDENCIES $PROJECT/DEPENDENCIES
+    echo "Looking for changes in production dependencies list..."
+    DIFFER_PROD=$(comm --nocheck-order -3 $DEPS_DIR/prod.md $TMP_DIR/prod.md)
+    echo "Done."
+    echo
 fi
 
-if [ -n "$DIFFER" ]; then
-    echo "Error: The generated dependencies list differs from one in the project. Please regenerate and commit DEPENDENCIES file."
+if [ -n "$CHECK" ]; then
+    echo "Looking for changes in test- and development dependencies list..."
+    DIFFER_DEV=$(comm --nocheck-order -3 $DEPS_DIR/dev.md $TMP_DIR/dev.md)
+    echo "Done."
+    echo
+fi
+
+if [ -z "$CHECK" ]; then
+    cp $TMP_DIR/prod.md $DEPS_DIR/prod.md
+    cp $TMP_DIR/dev.md $DEPS_DIR/dev.md
+fi
+if [ -z "$DEBUG" ]; then
+    rm -r $TMP_DIR
+fi
+
+if [ -n "$DIFFER_PROD" ]; then
+    echo "Error: The list of production dependencies is outdated. Please run the following command and commit changes:"
+    build_info_msg
+fi
+if [ -n "$DIFFER_DEV" ]; then
+    echo "Error: The list of development dependencies is outdated. Please run the following command and commit changes:"
+    build_info_msg
 fi
 if [ $RESTRICTED -ne 0 ]; then
     echo "Error: Restricted dependencies are found in the project."
 fi
-if [ -z "$DIFFER" ] && [ $RESTRICTED -eq 0 ]; then
+if [ -z "$DIFFER_PROD" ] && [ -z "$DIFFER_DEV" ] && [ $RESTRICTED -eq 0 ]; then
     echo "All found licenses are approved to use."
 else
     exit 1


### PR DESCRIPTION
Run the following command in a project directory to (re)generate `DEPENDENCIES`, `.deps/prod.md` and `.deps/dev.md` files:

```bash
docker run -v $(pwd):/workspace/project \
  quay.io/che-incubator/dash-licenses:next
```
The next command can be used to check that the existing file `DEPENDENCIES` is up-to-date and all dependencies are approved to use:

```bash
docker run \
  -v $(pwd):/workspace/project \
  quay.io/che-incubator/dash-licenses:next --check
```