### PR TITLE
Changed revision of Eclipse Dash Licenses tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN microdnf install -y git
 ARG MAVEN_VERSION=3.6.3
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 # https://github.com/eclipse/dash-licenses/commits Jan 25, 2021
-ARG DASH_LICENSE_REV=88b29e82ba9d4b83f86e3842fc942e2513666534
+ARG DASH_LICENSE_REV=635dc2e98c03d249a74864f8294bb68a8f163e26
 
 RUN mkdir -p /usr/local/apache-maven /usr/local/apache-maven/ref \
   && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \


### PR DESCRIPTION
The [latest commit](https://github.com/eclipse/dash-licenses/commit/635dc2e98c03d249a74864f8294bb68a8f163e26) of the Eclipse Dash Licenses is used.

This revision properly considers `jose@2.0.4` as resolved via `ClearlyDefined`. Once a new docker image is built, we'll be able to add the GH workflow job to automatically check dependencies for restrictions to use in Eclipse projects: https://github.com/eclipse/che-dashboard/pull/188