### PR TITLE
fix: add network timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM docker.io/openjdk:16-jdk
 
 RUN microdnf install -y git rsync
 
-ARG MAVEN_VERSION=3.8.5
+ARG MAVEN_VERSION=3.8.6
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 # https://github.com/eclipse/dash-licenses/commits May 18, 2022
 ARG DASH_LICENSE_REV=6d3828a707cbeffff8280471a9241db6e69b4b47

--- a/src/package-manager/yarn/start.sh
+++ b/src/package-manager/yarn/start.sh
@@ -29,7 +29,7 @@ if [ ! -f $PROJECT_COPY_DIR/yarn.lock ]; then
 fi
 
 echo "Generating all dependencies info using yarn..."
-yarn licenses list --ignore-engines --json --depth=0 --no-progres > "$TMP_DIR/yarn-deps-info.json"
+yarn licenses list --ignore-engines --json --depth=0 --no-progres --network-timeout 300000 > "$TMP_DIR/yarn-deps-info.json"
 echo "Done."
 echo
 


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

Test image here: [quay.io/dkwon17/dash-licenses:local](quay.io/dkwon17/dash-licenses:local) 

This PR increases the yarn network-timeout to 300000 milliseconds (5 minutes) which helps prevent a `ESOCKETTIMEDOUT` issue I've been experiencing:
```
$ git clone https://github.com/eclipse-che/che-dashboard
$ cd che-dashboard
$ docker run --rm -t -v ${PWD}/:/workspace/project quay.io/che-incubator/dash-licenses:next --check
Copy project...
Done.

Create tmp dir...
Done.
Generating all dependencies info using yarn...
{"type":"warning","data":"Pattern [\"@devfile/api@latest\"] is trying to unpack in the same destination \"/usr/local/share/.cache/yarn/v6/npm-@devfile-api-2.2.0-alpha-1646855991-integrity/node_modules/@devfile/api\" as pattern [\"@devfile/api@^2.2.0-alpha-1633545768\",\"@devfile/api@^2.2.0-alpha-1633545768\"]. This could result in non-deterministic behavior, skipping."}
Doc{"type":"error","data":"An unexpected error occurred: \"https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.49.19.tgz: ESOCKETTIMEDOUT\"."}
```

