### PR TITLE
Upgrade dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,31 @@
 # Contributors:
 #   Red Hat, Inc. - initial API and implementation
 
-FROM quay.io/devfile/universal-developer-image:ubi8-latest
+FROM docker.io/openjdk:23-jdk
+
+RUN microdnf install -y git rsync
+
+ARG MAVEN_VERSION=3.9.6
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+# https://github.com/eclipse/dash-licenses/commits Apr 23, 2024
+ARG DASH_LICENSE_REV=0001fc18bde5b736ca659b37b429ee55b8610efb
+
+RUN mkdir -p /usr/local/apache-maven /usr/local/apache-maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/local/apache-maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/local/apache-maven/bin/mvn /usr/bin/mvn
+
+ENV NODE_VERSION=v20.12.0
+ENV NODE_DISTRO=linux-x64
+ENV NODE_BASE_URL=https://nodejs.org/dist/${NODE_VERSION}
+
+RUN curl -fsSL ${NODE_BASE_URL}/node-${NODE_VERSION}-${NODE_DISTRO}.tar.gz -o node-${NODE_VERSION}-${NODE_DISTRO}.tar.gz \
+  && mkdir -p /usr/local/lib/nodejs \
+  && tar -xzf node-${NODE_VERSION}-${NODE_DISTRO}.tar.gz -C /usr/local/lib/nodejs \
+  && rm node-${NODE_VERSION}-${NODE_DISTRO}.tar.gz
+
+ENV PATH=/usr/local/lib/nodejs/node-${NODE_VERSION}-${NODE_DISTRO}/bin/:$PATH
 
 RUN npm install yarn synp -g
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # Contributors:
 #   Red Hat, Inc. - initial API and implementation
 
-FROM docker.io/openjdk:23-jdk
+FROM quay.io/ubi8/openjdk-21:latest
 
 RUN microdnf install -y git rsync
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It supports the following package managers:
 ## Build
 
 ```sh
-./build.sh
+scripts/build.sh
 ```
 
 ## Usage

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-# Simple script that helps to build local version to test easily
-set -e
-set -u
-
-docker build -f Dockerfile -t quay.io/che-incubator/dash-licenses:local .

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Simple script that helps to build local version to test easily
+set -e
+set -u
+
+${PWD}/scripts/container_tool.sh build -f Dockerfile -t quay.io/che-incubator/dash-licenses:local .

--- a/scripts/container_tool.sh
+++ b/scripts/container_tool.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Function to check if a command is available
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Check for Podman
+if command_exists "podman"; then
+    # Check if Podman machine is running
+    if podman info &>/dev/null; then
+        container_engine="podman"
+    fi
+fi
+
+# Check for Docker
+if command_exists "docker"; then
+    # Check if Docker daemon is running
+    if docker info &>/dev/null; then
+        container_engine="docker"
+    fi
+fi
+
+# If neither Podman nor Docker is found or running
+if [ -z "$container_engine" ]; then
+    echo "Neither Podman nor Docker is installed or running."
+    exit 1
+fi
+
+# Run command using Docker or Podman whichever is available
+container_tool() {
+    local command=$1
+    shift
+
+    echo "Container engine: $container_engine"
+    "$container_engine" "$command" "$@"
+}
+
+# Main script
+case "$1" in
+build | run | push)
+    set -e
+    container_tool "$@"
+    ;;
+*)
+    echo "Unknown command. Use: build, run, or push."
+    exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
What does this PR do?
This PR brings several improvements:

change  'quay.io/devfile/universal-developer-image' to 'quay.io/ubi8/openjdk-21';
upgrade maven to '3.9.6';
upgrade node to '20.12.0';
upgrade dash-license to '0001fc18bde5b736ca659b37b429ee55b8610efb' (Apr 23, 2024);