### PR TITLE
fix: exit code

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,4 +3,4 @@
 set -e
 set -u
 
-${PWD}/scripts/container_tool.sh build -f Dockerfile -t quay.io/che-incubator/dash-licenses:local .
+${PWD}/scripts/container_tool.sh build . -f Dockerfile -t quay.io/che-incubator/dash-licenses:local

--- a/scripts/container_tool.sh
+++ b/scripts/container_tool.sh
@@ -14,10 +14,12 @@ if command_exists "podman"; then
 fi
 
 # Check for Docker
-if command_exists "docker"; then
-    # Check if Docker daemon is running
-    if docker info &>/dev/null; then
-        container_engine="docker"
+if [ -z "$container_engine" ]; then
+    if command_exists "docker"; then
+        # Check if Docker daemon is running
+        if docker info &>/dev/null; then
+            container_engine="docker"
+        fi
     fi
 fi
 

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -54,6 +54,7 @@ if [ ! -f $PROJECT_DIR/yarn.lock ] && [ ! -f $PROJECT_DIR/package-lock.json ] &&
         exit $EXIT_CODE
     fi
     echo "Error: Can't find any package manager file."
+    ls -la $PROJECT_DIR
     exit $EXIT_CODE
 fi
 

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -26,14 +26,9 @@ if [ "$1" != "--help" ] && [ "$1" != "--check" ] && [ "$1" != "--generate" ] && 
     exit 0
 fi
 
-CHECK=""
+EXIT_CODE=0
 if [ "$1" = "--check" ]; then
-    CHECK="$1"
-fi
-
-DEBUG=""
-if [ "$1" = "--debug" ]; then
-    DEBUG="$1"
+    EXIT_CODE=1
 fi
 
 export ENCODING=utf8
@@ -49,16 +44,16 @@ export DASH_LICENSES=$WORKSPACE_DIR/dash-licenses.jar
 if [ ! -d $PROJECT_DIR ]; then
     echo
     echo "Error: The project directory is not mounted."
-    exit 1
+    exit $EXIT_CODE
 fi
 
 if [ ! -f $PROJECT_DIR/yarn.lock ] && [ ! -f $PROJECT_DIR/package-lock.json ] && [ ! -f $PROJECT_DIR/pom.xml ]; then
     if [ -f $PROJECT_DIR/package.json ]; then
         echo "Error: Can't find lock file. Generate and commit the lock file and then try again."
-        exit 1
+        exit $EXIT_CODE
     fi
     echo "Error: Can't find any package manager file."
-    exit 1
+    exit $EXIT_CODE
 fi
 
 if [ ! -d $DEPS_DIR ]; then
@@ -83,7 +78,7 @@ fi
 
 if [ ! -f $DASH_LICENSES ]; then
     echo "Error: Can't find dash-licenses.jar. Contact https://github.com/che-incubator/dash-licenses maintainers to fix the issue."
-    exit 1
+    exit $EXIT_CODE
 fi
 
 cd $PROJECT_COPY_DIR
@@ -112,4 +107,4 @@ if [ -f $PROJECT_COPY_DIR/package.json ]; then
 fi
 
 echo "Error: Can't find any supported package manager file."
-exit 1
+exit $EXIT_CODE

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -50,6 +50,7 @@ fi
 if [ ! -f $PROJECT_DIR/yarn.lock ] && [ ! -f $PROJECT_DIR/package-lock.json ] && [ ! -f $PROJECT_DIR/pom.xml ]; then
     if [ -f $PROJECT_DIR/package.json ]; then
         echo "Error: Can't find lock file. Generate and commit the lock file and then try again."
+        ls -la $PROJECT_DIR
         exit $EXIT_CODE
     fi
     echo "Error: Can't find any package manager file."


### PR DESCRIPTION
### What does this PR do?
This PR fixes the exit code for '--generate' and '--debug' flows.

### What issues does this PR fix or reference?
It is needed for https://github.com/eclipse-che/che/issues/23363

### Is it tested? How?
1. Create a new workspace with a URL ```https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com#https://github.com/olexii4/che-code/tree/CHE-23363```
2. Open a terminal in the created workspace and execute the next commands: 
```sh
npm --prefix code/extensions/che-api install
npm --prefix code/extensions/che-api run license:generate
```
The output should be ``` Error: Can't find any package manager file. ```