### PR TITLE
chore: rename package to @eclipse-che/license-tool and add npm publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-name: Release
+name: CI
 
 on:
   push:

--- a/.github/workflows/license-tool-release.yml
+++ b/.github/workflows/license-tool-release.yml
@@ -44,7 +44,9 @@ jobs:
         run: |
           RECREATE_TAGS="${{ github.event.inputs.forceRecreateTags }}"
           VERSION="${{ github.event.inputs.version }}"
-          if git ls-remote --exit-code origin "refs/tags/${VERSION}" >/dev/null 2>&1; then
+          git ls-remote --exit-code origin "refs/tags/${VERSION}" >/dev/null 2>&1
+          TAG_RC=$?
+          if [[ ${TAG_RC} -eq 0 ]]; then
             if [[ "${RECREATE_TAGS}" == "true" ]]; then
               echo "[INFO] Removing tag for ${VERSION} version. New tag will be recreated during release."
               git tag -d "${VERSION}" 2>/dev/null || true
@@ -53,8 +55,11 @@ jobs:
               echo "[ERROR] Cannot proceed with release - tag ${VERSION} already exists."
               exit 1
             fi
-          else
+          elif [[ ${TAG_RC} -eq 2 ]]; then
             echo "[INFO] No existing tags detected for ${VERSION}"
+          else
+            echo "[ERROR] Failed to verify remote tags for ${VERSION} (exit code: ${TAG_RC})"
+            exit 1
           fi
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/license-tool-release.yml
+++ b/.github/workflows/license-tool-release.yml
@@ -1,0 +1,72 @@
+#
+# Copyright (c) 2022-2026 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+name: Release @eclipse-che/license-tool
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'release version in format x.y.z'
+        required: true
+      forceRecreateTags:
+        description: If true, tags will be recreated. Use with caution
+        required: false
+        default: 'false'
+
+jobs:
+  build:
+    name: Create @eclipse-che/license-tool Release
+    runs-on: ubuntu-22.04
+    steps:
+      - name: "Checkout source code"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@eclipse-che'
+      - name: Set up environment
+        run: |
+          sudo apt-get update -y || true
+          sudo apt-get -y -q install hub
+          hub --version
+      - name: Check existing tags
+        run: |
+          set +e
+          RECREATE_TAGS=${{ github.event.inputs.forceRecreateTags }}
+          VERSION=${{ github.event.inputs.version }}
+          EXISTING_TAG=$(git ls-remote --exit-code origin refs/tags/${VERSION})
+          if [[ -n ${EXISTING_TAG} ]]; then
+            if [[ ${RECREATE_TAGS} == "true" ]]; then
+              echo "[INFO] Removing tag for ${VERSION} version. New tag will be recreated during release."
+              git push origin :$VERSION
+            else
+              echo "[ERROR] Cannot proceed with release - tag ${EXISTING_TAG} already exists."
+              exit 1
+            fi
+          else
+            echo "[INFO] No existing tags detected for $VERSION"
+          fi
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+      - name: Run make-release.sh script
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.LICENSE_TOOL_RELEASE_GITHUB_TOKEN }}
+        run: |
+          git config --global user.name "Oleksii Orel"
+          git config --global user.email "oorel@redhat.com"
+
+          ./make-release.sh --version ${{ github.event.inputs.version }}

--- a/.github/workflows/license-tool-release.yml
+++ b/.github/workflows/license-tool-release.yml
@@ -69,6 +69,8 @@ jobs:
       - name: Run make-release.sh script
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Custom PAT is used instead of default GITHUB_TOKEN so that
+          # commits and PRs created by this workflow can trigger other CI workflows.
           GITHUB_TOKEN: ${{ secrets.LICENSE_TOOL_RELEASE_GITHUB_TOKEN }}
         run: |
           git config --global user.name "github-actions[bot]"

--- a/.github/workflows/license-tool-release.yml
+++ b/.github/workflows/license-tool-release.yml
@@ -22,7 +22,8 @@ on:
 
 permissions:
   id-token: write  # Required for publishing to npmjs
-  contents: read
+  contents: write
+  pull-requests: write
 
 
 jobs:
@@ -39,27 +40,21 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
           scope: '@eclipse-che'
-      - name: Set up environment
-        run: |
-          sudo apt-get update -y || true
-          sudo apt-get -y -q install hub
-          hub --version
       - name: Check existing tags
         run: |
-          set +e
-          RECREATE_TAGS=${{ github.event.inputs.forceRecreateTags }}
-          VERSION=${{ github.event.inputs.version }}
-          EXISTING_TAG=$(git ls-remote --exit-code origin refs/tags/${VERSION})
-          if [[ -n ${EXISTING_TAG} ]]; then
-            if [[ ${RECREATE_TAGS} == "true" ]]; then
+          RECREATE_TAGS="${{ github.event.inputs.forceRecreateTags }}"
+          VERSION="${{ github.event.inputs.version }}"
+          if git ls-remote --exit-code origin "refs/tags/${VERSION}" >/dev/null 2>&1; then
+            if [[ "${RECREATE_TAGS}" == "true" ]]; then
               echo "[INFO] Removing tag for ${VERSION} version. New tag will be recreated during release."
-              git push origin :$VERSION
+              git tag -d "${VERSION}" 2>/dev/null || true
+              git push origin :"${VERSION}"
             else
-              echo "[ERROR] Cannot proceed with release - tag ${EXISTING_TAG} already exists."
+              echo "[ERROR] Cannot proceed with release - tag ${VERSION} already exists."
               exit 1
             fi
           else
-            echo "[INFO] No existing tags detected for $VERSION"
+            echo "[INFO] No existing tags detected for ${VERSION}"
           fi
       - uses: actions/cache@v4
         with:
@@ -71,7 +66,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.LICENSE_TOOL_RELEASE_GITHUB_TOKEN }}
         run: |
-          git config --global user.name "Oleksii Orel"
-          git config --global user.email "oorel@redhat.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          ./make-release.sh --version ${{ github.event.inputs.version }}
+          ./make-release.sh --version "${{ github.event.inputs.version }}"

--- a/.github/workflows/license-tool-release.yml
+++ b/.github/workflows/license-tool-release.yml
@@ -20,6 +20,11 @@ on:
         required: false
         default: 'false'
 
+permissions:
+  id-token: write  # Required for publishing to npmjs
+  contents: read
+
+
 jobs:
   build:
     name: Create @eclipse-che/license-tool Release

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,34 @@
+# Source and test files (dist/ and src/ are included via "files" in package.json)
+tests/
+docs/
+openspec/
+tmp/
+coverage/
+
+# Config and tooling
+.config/
+.cursor/
+.claude/
+.idea/
+.vscode/
+.github/
+.deps/
+
+# Build config
+webpack.config.js
+jest.config.js
+eslint.config.mjs
+tsconfig.json
+header-check.js
+.eslintignore
+
+# Lockfiles and other dev artifacts
+package-lock.json
+*.tsbuildinfo
+*.log
+*.tmp
+*.temp
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -212,7 +212,6 @@ npm run lint
 | `npm run lint` | Run ESLint |
 | `npm run header:check` | Check license headers |
 | `npm run type-check` | TypeScript type check (no emit) |
-| `npm run publish:next` | Publish a timestamped next-tagged version to npm |
 
 ## Risks and Limitations
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
-# license-tool
+# @eclipse-che/license-tool
+
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://workspaces.openshift.com#https://github.com/che-incubator/dash-licenses)
+[![Contribute (nightly)](https://img.shields.io/static/v1?label=nightly%20Che&message=for%20maintainers&logo=eclipseche&color=FDB940&labelColor=525C86)](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com#https://github.com/che-incubator/dash-licenses)
 
 Node.js library for dependency license analysis of **npm and Yarn** projects. Uses the [ClearlyDefined](https://clearlydefined.io/) HTTP API to resolve licenses—no Java, no containers required.
 
 ## Features
 
 - **Pure Node.js**: No Java/JAR—uses ClearlyDefined HTTP API
-- **npm & Yarn support**: npm (package-lock.json), Yarn v1, Yarn 3+
-- **SPDX-based license policy**: Approves MIT, Apache-2.0, BSD, ISC, EPL-2.0, etc.
-- **Use as library or CLI**: Programmatic API and `npx license-tool` command
+- **npm & Yarn support**: npm (`package-lock.json`), Yarn v1, Yarn 3+
+- **SPDX-based license policy**: Approves MIT, Apache-2.0, BSD, ISC, EPL-2.0, and more
+- **Use as library or CLI**: Programmatic API and `npx @eclipse-che/license-tool` command
+- **Eclipse IP compliance**: Optional JAR fallback for full IPLab/CQ integration
 
 ## Eclipse IP Compliance
 
@@ -15,34 +19,67 @@ By default, this tool uses the **ClearlyDefined** HTTP API as its primary licens
 
 ## Supported Package Managers
 
-- [npm](https://docs.npmjs.com) (`package-lock.json`)
-- [Yarn v1](https://classic.yarnpkg.com) (`yarn.lock` with Yarn < 2)
-- [Yarn 3+](https://yarnpkg.com) (`yarn.lock` with Yarn >= 3)—parses lockfile directly, no plugins required
+| Package Manager | Lock File |
+|---|---|
+| [npm](https://docs.npmjs.com) | `package-lock.json` |
+| [Yarn v1](https://classic.yarnpkg.com) | `yarn.lock` (Yarn < 2) |
+| [Yarn 3+](https://yarnpkg.com) | `yarn.lock` (Yarn >= 3) — parsed directly, no plugins required |
 
 ## Requirements
 
 - Node.js >= 20.0.0
+
+## Installation
+
+```sh
+npm install @eclipse-che/license-tool
+# or
+yarn add @eclipse-che/license-tool
+```
+
+## Where is it Published?
+
+This library is available on npm.
+
+You can find the published package here: \
+__npm:__ [@eclipse-che/license-tool](https://www.npmjs.com/package/@eclipse-che/license-tool)
 
 ## Quick Start
 
 ### CLI
 
 ```sh
-# From project directory (generate prod.md, dev.md in .deps/)
-npx license-tool
+# Generate prod.md and dev.md in .deps/ (default)
+npx @eclipse-che/license-tool
 
-# Check only (no generation)
-npx license-tool --check
+# Check only — fails if existing .deps files are outdated
+npx @eclipse-che/license-tool --check
 
-# With options
-npx license-tool --batch 200 --debug /path/to/project
+# Target a specific project directory
+npx @eclipse-che/license-tool /path/to/project
 
-# With JAR fallback for unresolved dev dependencies
-npx license-tool --jar /path/to/dash-licenses.jar
+# Tune batch size for ClearlyDefined API calls
+npx @eclipse-che/license-tool --batch 200
 
-# Auto-request harvest for unresolved dependencies (ClearlyDefined)
-npx license-tool --harvest
+# Auto-request harvest for unresolved dependencies
+npx @eclipse-che/license-tool --harvest
+
+# JAR fallback for unresolved dev dependencies
+npx @eclipse-che/license-tool --jar /path/to/dash-licenses.jar
 ```
+
+#### CLI Options
+
+| Option | Description | Default |
+|---|---|---|
+| `[projectPath]` | Path to project directory | current working directory |
+| `--generate` | (Re)generate dependency files | default mode |
+| `--check` | Check only, do not write any files | `false` |
+| `--batch <n>` | Batch size for ClearlyDefined API requests | `500` |
+| `--harvest` | Request harvest for unresolved deps from ClearlyDefined | `false` |
+| `--jar <path>` | Path to Eclipse `dash-licenses.jar` for fallback on unresolved dev deps | — |
+| `--debug` | Copy tmp files for inspection | `false` |
+| `--help` | Show help message | — |
 
 #### Downloading the Eclipse Dash JAR
 
@@ -54,8 +91,8 @@ The `--jar` option enables fallback to the official Eclipse Dash License Tool fo
 
 **Download**:
 ```sh
-# Download the latest dash-licenses JAR
-curl -o dash-licenses.jar https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=LATEST
+# Download the latest stable dash-licenses JAR (1.1.0)
+curl -Lo dash-licenses.jar https://repo.eclipse.org/repository/dash-maven2/org/eclipse/dash/org.eclipse.dash.licenses/1.1.0/org.eclipse.dash.licenses-1.1.0.jar
 ```
 
 **Resources**:
@@ -79,15 +116,15 @@ The `--harvest` flag enables automatic harvest requests for unresolved dependenc
 1. For each unresolved dependency, check if it was already harvested (`GET /harvest/{coordinate}`)
 2. If not harvested, request a new harvest (`POST /harvest`)
 3. ClearlyDefined queues the harvest job (typically completes in minutes to hours)
-4. Re-run `npx license-tool` after harvest completes to pick up new license data
+4. Re-run `npx @eclipse-che/license-tool` after harvest completes to pick up new license data
 
 **Example**:
 ```sh
 # Request harvest for unresolved dependencies
-npx license-tool --harvest
+npx @eclipse-che/license-tool --harvest
 
 # Wait for harvest to complete, then re-run
-npx license-tool
+npx @eclipse-che/license-tool
 ```
 
 See [docs/harvest.md](docs/harvest.md) for detailed documentation.
@@ -95,15 +132,15 @@ See [docs/harvest.md](docs/harvest.md) for detailed documentation.
 ### Library
 
 ```typescript
-import { generate } from 'license-tool';
+import { generate } from '@eclipse-che/license-tool';
 
 const result = await generate({
   projectPath: '/path/to/project',
   batchSize: 500,
   check: false,
   debug: false,
-  harvest: false,  // Optional: Auto-request harvest for unresolved dependencies (ClearlyDefined)
-  jarPath: '/path/to/dash-licenses.jar'  // Optional: Eclipse JAR fallback for unresolved dev deps
+  harvest: false,
+  jarPath: '/path/to/dash-licenses.jar', // optional
 });
 
 if (result.exitCode === 0) {
@@ -117,39 +154,35 @@ if (result.exitCode === 0) {
 
 Generated in `.deps/`:
 
-- `prod.md` - Production dependencies
-- `dev.md` - Development dependencies
-- `problems.md` - Unresolved or restricted dependencies
-- `EXCLUDED/prod.md`, `EXCLUDED/dev.md` - Manual exclusions
-
-## Installation
-
-```sh
-npm install license-tool
-# or
-yarn add license-tool
-```
+| File | Description |
+|---|---|
+| `prod.md` | Production dependencies |
+| `dev.md` | Development dependencies |
+| `problems.md` | Unresolved or restricted dependencies |
+| `EXCLUDED/prod.md` | Manually excluded production deps |
+| `EXCLUDED/dev.md` | Manually excluded dev deps |
 
 ## API
 
 ### `generate(config: LibraryConfig): Promise<LibraryResult>`
 
-| Option       | Type    | Default | Description                                                    |
-|--------------|---------|---------|----------------------------------------------------------------|
-| projectPath  | string  | required| Path to project directory                                      |
-| batchSize    | number  | 500     | Batch size for API requests                                    |
-| check        | boolean | false   | Check only, do not generate                                     |
-| debug        | boolean | false   | Copy tmp files for inspection                                   |
-| jarPath      | string  | -       | Optional path to Eclipse dash-licenses.jar; when set, runs JAR fallback for unresolved dev deps, adds approved to EXCLUDED, and regenerates docs |
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `projectPath` | `string` | required | Path to project directory (must contain `package.json` and a lock file) |
+| `batchSize` | `number` | `500` | Batch size for ClearlyDefined API requests |
+| `check` | `boolean` | `false` | Check only — do not write any files |
+| `debug` | `boolean` | `false` | Copy tmp directory for inspection |
+| `harvest` | `boolean` | `false` | Request harvest for unresolved dependencies from ClearlyDefined |
+| `jarPath` | `string` | — | Path to Eclipse `dash-licenses.jar`; runs JAR fallback for unresolved dev deps, adds approved items to `EXCLUDED`, and regenerates `dev.md` |
 
-Returns `{ exitCode: 0|1, error?: string }`.
+Returns `Promise<{ exitCode: 0 | 1; error?: string }>`.
 
 ## Project Structure
 
 ```
-license-tool/
+@eclipse-che/license-tool/
 ├── src/
-│   ├── library.ts          # Main library API
+│   ├── library.ts           # Main library API
 │   ├── cli.ts               # CLI entry point
 │   ├── backends/            # License resolution (ClearlyDefined)
 │   ├── document/            # Document generation
@@ -170,20 +203,26 @@ npm run lint
 
 ### Scripts
 
-- `npm run build` - Compile TypeScript
-- `npm test` - Run tests
-- `npm run lint` - ESLint
-- `npm run header:check` - License header check
+| Script | Description |
+|---|---|
+| `npm run build` | Compile TypeScript with webpack |
+| `npm test` | Run all tests |
+| `npm run test:unit` | Run unit tests only |
+| `npm run test:e2e` | Run end-to-end tests |
+| `npm run lint` | Run ESLint |
+| `npm run header:check` | Check license headers |
+| `npm run type-check` | TypeScript type check (no emit) |
+| `npm run publish:next` | Publish a timestamped next-tagged version to npm |
 
 ## Risks and Limitations
 
 - **ClearlyDefined coverage**: Newly published packages may not be indexed yet; use `--jar` or `--harvest` to resolve them
-- **Approval rules**: Maintain `src/backends/license-policy.ts` per [Eclipse licenses](https://www.eclipse.org/legal/licenses/) if desired
+- **Approval rules**: Maintain `src/backends/license-policy.ts` per [Eclipse licenses](https://www.eclipse.org/legal/licenses/) as needed
 
 ## Related Projects
 
-- [ClearlyDefined](https://clearlydefined.io/) - License data source
-- [Eclipse Dash License Tool](https://github.com/eclipse-dash/dash-licenses) - Original Java tool
+- [ClearlyDefined](https://clearlydefined.io/) — License data source
+- [Eclipse Dash License Tool](https://github.com/eclipse-dash/dash-licenses) — Original Java tool
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ yarn add @eclipse-che/license-tool
 This library is available on npm.
 
 You can find the published package here: \
-__npm:__ [@eclipse-che/license-tool](https://www.npmjs.com/package/@eclipse-che/license-tool)
+**npm:** [@eclipse-che/license-tool](https://www.npmjs.com/package/@eclipse-che/license-tool)
 
 ## Quick Start
 
@@ -91,7 +91,7 @@ The `--jar` option enables fallback to the official Eclipse Dash License Tool fo
 
 **Download**:
 ```sh
-# Download the latest stable dash-licenses JAR (1.1.0)
+# Download dash-licenses JAR (1.1.0)
 curl -Lo dash-licenses.jar https://repo.eclipse.org/repository/dash-maven2/org/eclipse/dash/org.eclipse.dash.licenses/1.1.0/org.eclipse.dash.licenses-1.1.0.jar
 ```
 
@@ -179,7 +179,7 @@ Returns `Promise<{ exitCode: 0 | 1; error?: string }>`.
 
 ## Project Structure
 
-```
+```text
 @eclipse-che/license-tool/
 ├── src/
 │   ├── library.ts           # Main library API

--- a/make-release.sh
+++ b/make-release.sh
@@ -32,9 +32,9 @@ init() {
   while [[ "$#" -gt 0 ]]; do
     case $1 in
       '-v'|'--version') VERSION="$2"; shift 1;;
-      '--no-push') NO_PUSH=1; shift 0;;
-      '--skip-publish') SKIP_PUBLISH=1; shift 0;;
-      '--skip-bump-version') SKIP_NEXT_VERSION_BUMP=1; shift 0;;
+      '--no-push') NO_PUSH=1;;
+      '--skip-publish') SKIP_PUBLISH=1;;
+      '--skip-bump-version') SKIP_NEXT_VERSION_BUMP=1;;
       '--help'|'-h') usage;;
     esac
     shift 1
@@ -42,7 +42,12 @@ init() {
 
   [[ -z ${VERSION} ]] && { echo "[ERROR] Release version is not defined"; usage; }
 
-  X_BRANCH=$(echo "${VERSION}" | sed 's/.$/x/')
+  if [[ ! ${VERSION} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "[ERROR] Invalid version '${VERSION}'. Expected format: x.y.z"
+    exit 1
+  fi
+
+  X_BRANCH="${VERSION%?}x"
   NEXT_BRANCH="pr-main-to-${VERSION}-next"
   NEXT_VERSION="${VERSION}-next"
 

--- a/make-release.sh
+++ b/make-release.sh
@@ -115,7 +115,6 @@ publishArtifacts() {
   npm run build
 
   if [[ ${SKIP_PUBLISH} -eq 0 ]]; then
-    echo "[INFO] Publishing @eclipse-che/license-tool ${VERSION} artifacts"
     npm publish --tag latest --access public
   else
     echo "[INFO] Skipping publishing step"
@@ -138,7 +137,7 @@ createPR() {
 
   echo "[INFO] Create PR with base = ${base} and head = ${branch}"
 
-  existing_pr=$(gh pr list --base "${base}" --head "${branch}" --state open --json number --jq '.[0].number')
+  existing_pr=$(gh pr list --base "${base}" --head "${branch}" --state open --json number --jq '.[0].number' 2>/dev/null || true)
   if [[ -n "${existing_pr}" ]]; then
     echo "[INFO] PR #${existing_pr} already exists for ${branch} -> ${base}, skipping creation."
   else
@@ -151,8 +150,7 @@ updatePackageVersionAndCommitChanges() {
   local branch=$2
   local message=$3
 
-  local current_version=0
-
+  local current_version
   current_version=$(npm pkg get version)
   if [[ "$current_version" == "\"$version\"" ]]; then
     echo "[INFO] version is already specified in the package.json, skipping edits"

--- a/make-release.sh
+++ b/make-release.sh
@@ -13,13 +13,14 @@
 
 set -e
 
-usage ()
-{   echo "Usage: ./make-release.sh -v <version>"
+usage() {
+    local exit_code="${1:-0}"
+    echo "Usage: ./make-release.sh -v <version>"
     echo "optional parameters:"
     echo "--no-push - no pushes to remote repository"
     echo "--skip-publish - no publishing to npmjs repository"
     echo "--skip-bump-version - no updating of the next version after release"
-    exit
+    exit "${exit_code}"
 }
 
 init() {
@@ -35,12 +36,13 @@ init() {
       '--no-push') NO_PUSH=1;;
       '--skip-publish') SKIP_PUBLISH=1;;
       '--skip-bump-version') SKIP_NEXT_VERSION_BUMP=1;;
-      '--help'|'-h') usage;;
+      '--help'|'-h') usage 0;;
+      *) echo "[ERROR] Unknown argument: $1"; usage 1;;
     esac
     shift 1
   done
 
-  [[ -z ${VERSION} ]] && { echo "[ERROR] Release version is not defined"; usage; }
+  [[ -z ${VERSION} ]] && { echo "[ERROR] Release version is not defined"; usage 1; }
 
   if [[ ! ${VERSION} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo "[ERROR] Invalid version '${VERSION}'. Expected format: x.y.z"
@@ -157,10 +159,9 @@ updatePackageVersionAndCommitChanges() {
   else
     echo "[INFO] Setting ${version} in package.json"
 
-    jq --arg version "${version}" '.version |= $version' package.json > package.json.update
-    mv -f package.json.update package.json
+    npm version "${version}" --no-git-tag-version
 
-    git add package.json
+    git add package.json package-lock.json
     git commit -s -m "${message}"
     if [[ ${NO_PUSH} -eq 0 ]]; then
         git push origin "${branch}"
@@ -180,8 +181,8 @@ updateXBranch() {
     "${X_BRANCH}" \
     "${COMMIT_MSG}"
 
-  publishArtifacts
   tagRelease
+  publishArtifacts
 }
 
 updateMainBranch() {
@@ -194,10 +195,14 @@ updateMainBranch() {
     "${NEXT_BRANCH}" \
     "${COMMIT_MSG}"
 
-  createPR \
-    "main" \
-    "${NEXT_BRANCH}" \
-    "${COMMIT_MSG}"
+  if [[ ${NO_PUSH} -eq 0 ]]; then
+    createPR \
+      "main" \
+      "${NEXT_BRANCH}" \
+      "${COMMIT_MSG}"
+  else
+    echo "[INFO] Skipping PR creation step"
+  fi
 }
 
 run() {

--- a/make-release.sh
+++ b/make-release.sh
@@ -66,7 +66,7 @@ resetChanges() {
 checkoutToXBranch() {
   echo "[INFO] Check out to ${X_BRANCH} branch."
 
-  if [[ $(git ls-remote -q --heads | grep -c "${X_BRANCH}") == 1 ]]; then
+  if git ls-remote --exit-code --heads origin "refs/heads/${X_BRANCH}" >/dev/null 2>&1; then
     echo "[INFO] ${X_BRANCH} exists."
     resetChanges "${X_BRANCH}"
   else
@@ -85,7 +85,7 @@ checkoutToXBranch() {
 checkoutToNextBranch() {
   echo "[INFO] Check out to ${NEXT_BRANCH} branch."
 
-  if [[ $(git ls-remote -q --heads | grep -c "${NEXT_BRANCH}") == 1 ]]; then
+  if git ls-remote --exit-code --heads origin "refs/heads/${NEXT_BRANCH}" >/dev/null 2>&1; then
     echo "[INFO] ${NEXT_BRANCH} exists."
     resetChanges "${NEXT_BRANCH}"
   else
@@ -93,10 +93,11 @@ checkoutToNextBranch() {
     resetChanges "main"
     if [[ ${NO_PUSH} -eq 0 ]]; then
       git push origin main:"${NEXT_BRANCH}"
+      git checkout "${NEXT_BRANCH}"
     else
       echo "[INFO] Skipping pushing branch ${NEXT_BRANCH} step"
+      git checkout -b "${NEXT_BRANCH}"
     fi
-    git checkout "${NEXT_BRANCH}"
   fi
 }
 
@@ -129,7 +130,13 @@ createPR() {
   local message=$3
 
   echo "[INFO] Create PR with base = ${base} and head = ${branch}"
-  hub pull-request --base "${base}" --head "${branch}" -m "${message}"
+
+  existing_pr=$(gh pr list --base "${base}" --head "${branch}" --state open --json number --jq '.[0].number')
+  if [[ -n "${existing_pr}" ]]; then
+    echo "[INFO] PR #${existing_pr} already exists for ${branch} -> ${base}, skipping creation."
+  else
+    gh pr create --base "${base}" --head "${branch}" --title "${message}" --body ""
+  fi
 }
 
 updatePackageVersionAndCommitChanges() {

--- a/make-release.sh
+++ b/make-release.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+#
+# Copyright (c) 2022-2026 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+set -e
+
+usage ()
+{   echo "Usage: ./make-release.sh -v <version>"
+    exit
+}
+
+init() {
+  unset VERSION
+
+  while [[ "$#" -gt 0 ]]; do
+    case $1 in
+      '-v'|'--version') VERSION="$2"; shift 1;;
+      '--help'|'-h') usage;;
+    esac
+    shift 1
+  done
+
+  [[ -z ${VERSION} ]] && { echo "[ERROR] Release version is not defined"; usage; }
+
+  X_BRANCH=$(echo "${VERSION}" | sed 's/.$/x/')
+  NEXT_BRANCH="pr-main-to-${VERSION}-next"
+  NEXT_VERSION="${VERSION}-next"
+}
+
+resetChanges() {
+  local branch="$1"
+
+  echo "[INFO] Reset changes in ${branch} branch"
+
+  git reset --hard
+  git checkout "${branch}"
+  git fetch origin --prune
+  git pull origin "${branch}"
+}
+
+checkoutToXBranch() {
+  echo "[INFO] Check out to ${X_BRANCH} branch."
+
+  if [[ $(git ls-remote -q --heads | grep -c "${X_BRANCH}") == 1 ]]; then
+    echo "[INFO] ${X_BRANCH} exists."
+    resetChanges "${X_BRANCH}"
+  else
+    echo "[INFO] ${X_BRANCH} does not exist. Will be created a new one from main."
+    resetChanges "main"
+    git push origin main:"${X_BRANCH}"
+    git checkout "${X_BRANCH}"
+  fi
+}
+
+checkoutToNextBranch() {
+  echo "[INFO] Check out to ${NEXT_BRANCH} branch."
+
+  if [[ $(git ls-remote -q --heads | grep -c "${NEXT_BRANCH}") == 1 ]]; then
+    echo "[INFO] ${NEXT_BRANCH} exists."
+    resetChanges "${NEXT_BRANCH}"
+  else
+    echo "[INFO] ${NEXT_BRANCH} does not exist. Will be created a new one from main."
+    resetChanges "main"
+    git push origin main:"${NEXT_BRANCH}"
+    git checkout "${NEXT_BRANCH}"
+  fi
+}
+
+publishArtifacts() {
+  echo "[INFO] Publish @eclipse-che/license-tool ${VERSION} artifacts"
+
+  npm ci
+  npm run build
+  npm publish --tag latest --access public
+}
+
+tagRelease() {
+  git tag "${VERSION}"
+  git push origin "${VERSION}"
+}
+
+createPR() {
+  local base=$1
+  local branch=$2
+  local message=$3
+
+  echo "[INFO] Create PR with base = ${base} and head = ${branch}"
+  hub pull-request --base "${base}" --head "${branch}" -m "${message}"
+}
+
+updatePackageVersionAndCommitChanges() {
+  local version=$1
+  local branch=$2
+  local message=$3
+
+  echo "[INFO] Set ${version} in package.json"
+
+  jq --arg version "${version}" '.version |= $version' package.json > package.json.update
+  mv -f package.json.update package.json
+
+  echo "[INFO] Push changes to ${branch} branch"
+
+  git add package.json
+  git commit -s -m "${message}"
+  git push origin "${branch}"
+}
+
+updateXBranch() {
+  checkoutToXBranch
+
+  COMMIT_MSG="ci: bump ${VERSION} in ${X_BRANCH}"
+
+  updatePackageVersionAndCommitChanges \
+    "${VERSION}" \
+    "${X_BRANCH}" \
+    "${COMMIT_MSG}"
+
+  tagRelease
+  publishArtifacts
+}
+
+updateMainBranch() {
+  checkoutToNextBranch
+
+  COMMIT_MSG="ci: bump ${NEXT_VERSION} in main"
+
+  updatePackageVersionAndCommitChanges \
+    "${NEXT_VERSION}" \
+    "${NEXT_BRANCH}" \
+    "${COMMIT_MSG}"
+
+  createPR \
+    "main" \
+    "${NEXT_BRANCH}" \
+    "${COMMIT_MSG}"
+}
+
+run() {
+  updateXBranch
+  updateMainBranch
+}
+
+init "$@"
+run

--- a/make-release.sh
+++ b/make-release.sh
@@ -15,15 +15,26 @@ set -e
 
 usage ()
 {   echo "Usage: ./make-release.sh -v <version>"
+    echo "optional parameters:"
+    echo "--no-push - no pushes to remote repository"
+    echo "--skip-publish - no publishing to npmjs repository"
+    echo "--skip-bump-version - no updating of the next version after release"
     exit
 }
 
 init() {
   unset VERSION
 
+  SKIP_PUBLISH=0
+  SKIP_NEXT_VERSION_BUMP=0
+  NO_PUSH=0
+
   while [[ "$#" -gt 0 ]]; do
     case $1 in
       '-v'|'--version') VERSION="$2"; shift 1;;
+      '--no-push') NO_PUSH=1; shift 0;;
+      '--skip-publish') SKIP_PUBLISH=1; shift 0;;
+      '--skip-bump-version') SKIP_NEXT_VERSION_BUMP=1; shift 0;;
       '--help'|'-h') usage;;
     esac
     shift 1
@@ -34,6 +45,11 @@ init() {
   X_BRANCH=$(echo "${VERSION}" | sed 's/.$/x/')
   NEXT_BRANCH="pr-main-to-${VERSION}-next"
   NEXT_VERSION="${VERSION}-next"
+
+  echo "Running release script with following parameters:"
+  echo "no pushes to github: ${NO_PUSH}"
+  echo "no publishing to npmjs: ${SKIP_PUBLISH}"
+  echo "no bumping of the next version: ${SKIP_NEXT_VERSION_BUMP}"
 }
 
 resetChanges() {
@@ -56,8 +72,13 @@ checkoutToXBranch() {
   else
     echo "[INFO] ${X_BRANCH} does not exist. Will be created a new one from main."
     resetChanges "main"
-    git push origin main:"${X_BRANCH}"
-    git checkout "${X_BRANCH}"
+    if [[ ${NO_PUSH} -eq 0 ]]; then
+      git push origin main:"${X_BRANCH}"
+      git checkout "${X_BRANCH}"
+    else
+      echo "[INFO] Skipping pushing branch ${X_BRANCH} step"
+      git checkout -b "${X_BRANCH}"
+    fi
   fi
 }
 
@@ -70,22 +91,36 @@ checkoutToNextBranch() {
   else
     echo "[INFO] ${NEXT_BRANCH} does not exist. Will be created a new one from main."
     resetChanges "main"
-    git push origin main:"${NEXT_BRANCH}"
+    if [[ ${NO_PUSH} -eq 0 ]]; then
+      git push origin main:"${NEXT_BRANCH}"
+    else
+      echo "[INFO] Skipping pushing branch ${NEXT_BRANCH} step"
+    fi
     git checkout "${NEXT_BRANCH}"
   fi
 }
 
 publishArtifacts() {
-  echo "[INFO] Publish @eclipse-che/license-tool ${VERSION} artifacts"
+  echo "[INFO] Publishing @eclipse-che/license-tool ${VERSION} artifacts"
 
   npm ci
   npm run build
-  npm publish --tag latest --access public
+
+  if [[ ${SKIP_PUBLISH} -eq 0 ]]; then
+    echo "[INFO] Publishing @eclipse-che/license-tool ${VERSION} artifacts"
+    npm publish --tag latest --access public
+  else
+    echo "[INFO] Skipping publishing step"
+  fi
 }
 
 tagRelease() {
   git tag "${VERSION}"
-  git push origin "${VERSION}"
+  if [[ ${NO_PUSH} -eq 0 ]]; then
+    git push origin "${VERSION}"
+  else
+    echo "[INFO] Skipping pushing tag ${VERSION} step"
+  fi
 }
 
 createPR() {
@@ -102,16 +137,25 @@ updatePackageVersionAndCommitChanges() {
   local branch=$2
   local message=$3
 
-  echo "[INFO] Set ${version} in package.json"
+  local current_version=0
 
-  jq --arg version "${version}" '.version |= $version' package.json > package.json.update
-  mv -f package.json.update package.json
+  current_version=$(npm pkg get version)
+  if [[ "$current_version" == "\"$version\"" ]]; then
+    echo "[INFO] version is already specified in the package.json, skipping edits"
+  else
+    echo "[INFO] Setting ${version} in package.json"
 
-  echo "[INFO] Push changes to ${branch} branch"
+    jq --arg version "${version}" '.version |= $version' package.json > package.json.update
+    mv -f package.json.update package.json
 
-  git add package.json
-  git commit -s -m "${message}"
-  git push origin "${branch}"
+    git add package.json
+    git commit -s -m "${message}"
+    if [[ ${NO_PUSH} -eq 0 ]]; then
+        git push origin "${branch}"
+    else
+      echo "[INFO] Skipping pushing branch ${branch} step"
+    fi
+  fi
 }
 
 updateXBranch() {
@@ -124,8 +168,8 @@ updateXBranch() {
     "${X_BRANCH}" \
     "${COMMIT_MSG}"
 
-  tagRelease
   publishArtifacts
+  tagRelease
 }
 
 updateMainBranch() {
@@ -146,7 +190,11 @@ updateMainBranch() {
 
 run() {
   updateXBranch
-  updateMainBranch
+  if [[ ${SKIP_NEXT_VERSION_BUMP} -eq 0 ]]; then
+    updateMainBranch
+  else
+    echo "[INFO] Skipping next version bumping step"
+  fi
 }
 
 init "$@"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "license-tool",
+  "name": "@eclipse-che/license-tool",
   "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "license-tool",
+      "name": "@eclipse-che/license-tool",
       "version": "2.0.0",
       "license": "EPL-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
     "header:fix": "node header-check.js --fix",
     "header:verbose": "node header-check.js --verbose",
     "type-check": "tsc --noEmit",
-    "prepack": "webpack --mode production && chmod +x dist/cli.js",
-    "publish:next": "npm version 0.0.1-$(date +%s) --no-git-tag-version && npm publish --registry=https://registry.npmjs.org/ --tag next --access public"
+    "prepack": "webpack --mode production && chmod +x dist/cli.js"
   },
   "dependencies": {
     "@eslint/eslintrc": "3.3.4",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "license-tool",
+  "name": "@eclipse-che/license-tool",
   "version": "2.0.0",
   "description": "Node.js library for dependency license analysis using ClearlyDefined API",
   "main": "dist/index.js",
@@ -7,6 +7,13 @@
   "bin": {
     "license-tool": "dist/cli.js"
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/che-incubator/dash-licenses.git"
@@ -48,7 +55,8 @@
     "header:fix": "node header-check.js --fix",
     "header:verbose": "node header-check.js --verbose",
     "type-check": "tsc --noEmit",
-    "prepack": "webpack --mode production && chmod +x dist/cli.js"
+    "prepack": "webpack --mode production && chmod +x dist/cli.js",
+    "publish:next": "npm version 0.0.1-$(date +%s) --no-git-tag-version && npm publish --registry=https://registry.npmjs.org/ --tag next --access public"
   },
   "dependencies": {
     "@eslint/eslintrc": "3.3.4",


### PR DESCRIPTION
### What does this PR do?
This PR brings several changes:
 - Renames the **npm** package from **license-tool** to **@eclipse-che/license-tool** (scoped under the Eclipse Che org)
 - Adds **make-release.sh** release automation script
 - Adds **.github/workflows/license-tool-release.yml** — a manual workflow_dispatch release workflow
 - Improves **README.md**: restructures sections, adds Eclipse Che contribution badges, npm package badge, fixes the broken Eclipse Dash JAR download URL.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23756

### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README: package renamed, expanded CLI quick-start/options, installation/publishing info, supported package managers, outputs and scripts tables, and examples.

* **Chores**
  * Rebranded package to @eclipse-che/license-tool and updated publish metadata and scripts.
  * Added .npmignore to exclude development/build artifacts.
  * Added an automated release workflow, a release helper script, and a publish:next prerelease script.

* **Style**
  * CI workflow display name changed to “CI”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->