### PR TITLE
chore: Add release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2026 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+
+  build-and-test:
+    runs-on: ubuntu-22.04
+    steps:
+      -
+        name: "Checkout"
+        uses: actions/checkout@v4
+      -
+        name: "Use Node.js"
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      -
+        name: "Install dependencies"
+        run: npm ci
+      -
+        name: "Build"
+        run: npm run build
+      -
+        name: "Run tests"
+        run: npm run test:unit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2025 Red Hat, Inc.
+# Copyright (c) 2021-2026 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -9,11 +9,18 @@
 name: Release
 
 on:
-  push:
-    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version that is going to be released. Should be in format 1.y.z'
+        required: true
+        default: '2.y.z'
+
+permissions:
+  id-token: write  # Required for publishing to npmjs
+  contents: read
 
 jobs:
-
   build-and-test:
     runs-on: ubuntu-22.04
     steps:
@@ -25,12 +32,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-      -
-        name: "Install dependencies"
-        run: npm ci
-      -
-        name: "Build"
-        run: npm run build
-      -
-        name: "Run tests"
-        run: npm run test:unit
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: "Release: publish to npmjs"
+        run: ./make-release.sh ${{ github.event.inputs.version }}

--- a/make-release.sh
+++ b/make-release.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Copyright (c) 2026 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+# release script
+# parameters
+# --prepare-branch
+
+# init default variables
+SKIP_PUBLISH=0
+SKIP_TAG=0
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    '-v'|'--version') RELEASE_VERSION="$2"; shift 1;;
+    '--skip-publish') SKIP_PUBLISH=1; shift 0;;
+    '--skip-tag') SKIP_TAG=1; shift 0;;
+  esac
+  shift 1
+done
+
+# parse variables
+RELEASE_BRANCH=main
+
+# checkout release branch
+# this project is only released from the main branch
+git checkout $RELEASE_BRANCH
+
+# validate version in package.json
+CURRENT_VERSION=$(npm pkg get version)
+if [[ "$CURRENT_VERSION" != "\"$RELEASE_VERSION\"" ]]; then
+  echo "release version is not specified in package.json! Aborting release"
+  exit 1;
+fi
+
+# build project
+npm ci
+npm run build
+
+# publish project
+if [[ ${SKIP_PUBLISH} -eq 0 ]]; then
+  npm publish
+else
+  echo "skipping publishing step"
+fi
+
+# tag release
+if [[ ${SKIP_TAG} -eq 0 ]]; then
+  git tag "$RELEASE_VERSION"
+  git push "$RELEASE_VERSION"
+else
+  echo "skipping tagging step"
+fi
+
+echo "end of release script"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "license-tool",
+  "name": "@eclipse-che/license-tool",
   "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "license-tool",
+      "name": "@eclipse-che/license-tool",
       "version": "2.0.0",
       "license": "EPL-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "license-tool",
+  "name": "@eclipse-che/license-tool",
   "version": "2.0.0",
   "description": "Node.js library for dependency license analysis using ClearlyDefined API",
   "main": "dist/index.js",


### PR DESCRIPTION
### What does this PR do?

- Update project name to correspond npmjs package - "@eclipse-che/license-tool"

- Add GH release pipeline
  - add make-release.sh script that will run release steps: build - publish - tag
  - release pipeline will use trusted publishing process (instead of manually added token secrets)

- Add ci.yaml pipeline to perform builds on pushes to main branch

### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/23756

### Is it tested? How?"
run following command to run release without publishing anything (just build the project and verify the version)
`make-release.sh -v 2.0.0 --skip-tag --skip-publish`

<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated testing workflow that runs on commits to the main branch
  * Updated release workflow to manual triggering with version configuration
  * Added release automation script for streamlined build and publish operations
  * Updated package name to scoped namespace

<!-- end of auto-generated comment: release notes by coderabbit.ai -->