### PR TITLE
Fix tag existence check in release workflow

### DIFF
--- a/.github/workflows/license-tool-release.yml
+++ b/.github/workflows/license-tool-release.yml
@@ -45,8 +45,8 @@ jobs:
           set -e
           RECREATE_TAGS="${{ github.event.inputs.forceRecreateTags }}"
           VERSION="${{ github.event.inputs.version }}"
-          git ls-remote --exit-code origin "refs/tags/${VERSION}" >/dev/null 2>&1
-          TAG_RC=$?
+          TAG_RC=0
+          git ls-remote --exit-code origin "refs/tags/${VERSION}" >/dev/null 2>&1 || TAG_RC=$?
           if [[ ${TAG_RC} -eq 0 ]]; then
             if [[ "${RECREATE_TAGS}" == "true" ]]; then
               echo "[INFO] Removing tag for ${VERSION} version. New tag will be recreated during release."


### PR DESCRIPTION
### What does this PR do?
The `git ls-remote --exit-code` command was not capturing
the exit code correctly when the tag did not exist, causing
the release workflow to fail.
