### PR TITLE
chore: switch to Trusted Publishing release process

### DIFF
--- a/.github/workflows/license-tool-release.yml
+++ b/.github/workflows/license-tool-release.yml
@@ -69,7 +69,6 @@ jobs:
           restore-keys: npm-
       - name: Run make-release.sh script
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           # Custom PAT is used instead of default GITHUB_TOKEN so that
           # commits and PRs created by this workflow can trigger other CI workflows.
           GITHUB_TOKEN: ${{ secrets.LICENSE_TOOL_RELEASE_GITHUB_TOKEN }}


### PR DESCRIPTION
### What does this PR do?
with Trusted Publishing enabled for this package on npmjs, the pipeline will now login without our supplies token secret
### What issues does this PR fix or reference?


### Is it tested? How?
<!-- 
Please provide instructions here which scenario you fix/implement
and in which way you tested it, provide as much as you think reviewer
needs to do the same.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->