### PR TITLE
feat: dependency cache, configurable timeouts, correct harvest scope

### DIFF
--- a/.deps/dev.md
+++ b/.deps/dev.md
@@ -398,7 +398,7 @@
 | `prompts@2.4.2` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/prompts/2.4.2) |
 | `punycode@2.3.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/punycode/2.3.1) |
 | `pure-rand@6.1.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/pure-rand/6.1.0) |
-| `qs@6.14.2` | BSD-3-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/qs/6.14.2) |
+| [`qs@6.15.2`](https://github.com/ljharb/qs) | BSD-3-Clause | transitive dependency |
 | `react-is@18.3.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/react-is/18.3.1) |
 | `rechoir@0.8.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/rechoir/0.8.0) |
 | `require-directory@2.1.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/require-directory/2.1.1) |

--- a/.deps/dev.md
+++ b/.deps/dev.md
@@ -252,7 +252,7 @@
 | `flat@5.0.2` | BSD-3-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/flat/5.0.2) |
 | `flatted@3.4.2` | ISC | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/flatted/3.4.2) |
 | `foreground-child@3.3.1` | ISC | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/foreground-child/3.3.1) |
-| `form-data@4.0.5` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/form-data/4.0.5) |
+| `form-data@4.0.6` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/form-data/4.0.6) |
 | `formidable@2.1.5` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/formidable/2.1.5) |
 | `fs.realpath@1.0.0` | ISC AND MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/fs.realpath/1.0.0) |
 | `function-bind@1.1.2` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/function-bind/1.1.2) |
@@ -398,7 +398,7 @@
 | `prompts@2.4.2` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/prompts/2.4.2) |
 | `punycode@2.3.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/punycode/2.3.1) |
 | `pure-rand@6.1.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/pure-rand/6.1.0) |
-| [`qs@6.15.2`](https://github.com/ljharb/qs) | BSD-3-Clause | transitive dependency |
+| `qs@6.15.2` | BSD-3-Clause | transitive dependency |
 | `react-is@18.3.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/react-is/18.3.1) |
 | `rechoir@0.8.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/rechoir/0.8.0) |
 | `require-directory@2.1.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/require-directory/2.1.1) |

--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -5,7 +5,7 @@
 | `@eslint/eslintrc@3.3.4` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@eslint/eslintrc/3.3.4) |
 | `@yarnpkg/parsers@3.0.3` | BSD-2-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@yarnpkg/parsers/3.0.3) |
 | `agent-base@6.0.2` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/agent-base/6.0.2) |
-| [`axios@1.16.1`](https://axios-http.com) | MIT | #28196 |
+| `axios@1.16.1` | MIT | #28196 |
 | `chalk@4.1.2` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/chalk/4.1.2) |
 | `follow-redirects@1.16.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/follow-redirects/1.16.0) |
 | `https-proxy-agent@5.0.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/https-proxy-agent/5.0.1) |

--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -5,7 +5,7 @@
 | `@eslint/eslintrc@3.3.4` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@eslint/eslintrc/3.3.4) |
 | `@yarnpkg/parsers@3.0.3` | BSD-2-Clause | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/@yarnpkg/parsers/3.0.3) |
 | `agent-base@6.0.2` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/agent-base/6.0.2) |
-| `axios@1.16.1` |  | #28196 |
+| [`axios@1.16.1`](https://axios-http.com) | MIT | #28196 |
 | `chalk@4.1.2` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/chalk/4.1.2) |
 | `follow-redirects@1.16.0` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/follow-redirects/1.16.0) |
 | `https-proxy-agent@5.0.1` | MIT | [clearlydefined](https://clearlydefined.io/definitions/npm/npmjs/-/https-proxy-agent/5.0.1) |

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ npx @eclipse-che/license-tool --jar /path/to/dash-licenses.jar
 | `--batch <n>` | Batch size for ClearlyDefined API requests | `500` |
 | `--harvest` | Request harvest for unresolved deps from ClearlyDefined | `false` |
 | `--recheck` | Bypass the `.deps/` cache and re-query ClearlyDefined for every dependency | `false` |
-| `--post-timeout <ms>` | Timeout for batch POST `/definitions` requests | `10000` ms |
+| `--post-timeout <ms>` | Timeout for batch POST `/definitions` requests | `30000` ms |
 | `--get-timeout <ms>` | Timeout for individual GET `/definitions/{id}` requests | `5000` ms |
 | `--jar <path>` | Path to Eclipse `dash-licenses.jar` for fallback on unresolved dev deps | — |
 | `--debug` | Copy tmp files for inspection | `false` |
@@ -186,6 +186,9 @@ Generated in `.deps/`:
 | `check` | `boolean` | `false` | Check only — do not write any files |
 | `debug` | `boolean` | `false` | Copy tmp directory for inspection |
 | `harvest` | `boolean` | `false` | Request harvest for unresolved dependencies from ClearlyDefined |
+| `recheck` | `boolean` | `false` | Bypass the `.deps/` cache and re-query ClearlyDefined for every dependency |
+| `postTimeout` | `number` | `30000` | Timeout (ms) for batch POST `/definitions` requests |
+| `getTimeout` | `number` | `5000` | Timeout (ms) for individual GET `/definitions/{id}` requests |
 | `jarPath` | `string` | — | Path to Eclipse `dash-licenses.jar`; runs JAR fallback for unresolved dev deps, adds approved items to `EXCLUDED`, and regenerates `dev.md` |
 
 Returns `Promise<{ exitCode: 0 | 1; error?: string }>`.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ npx @eclipse-che/license-tool --batch 200
 # Auto-request harvest for unresolved dependencies
 npx @eclipse-che/license-tool --harvest
 
+# Force a full re-query, bypassing the cache
+npx @eclipse-che/license-tool --recheck
+
 # JAR fallback for unresolved dev dependencies
 npx @eclipse-che/license-tool --jar /path/to/dash-licenses.jar
 ```
@@ -77,9 +80,16 @@ npx @eclipse-che/license-tool --jar /path/to/dash-licenses.jar
 | `--check` | Check only, do not write any files | `false` |
 | `--batch <n>` | Batch size for ClearlyDefined API requests | `500` |
 | `--harvest` | Request harvest for unresolved deps from ClearlyDefined | `false` |
+| `--recheck` | Bypass the `.deps/` cache and re-query ClearlyDefined for every dependency | `false` |
 | `--jar <path>` | Path to Eclipse `dash-licenses.jar` for fallback on unresolved dev deps | — |
 | `--debug` | Copy tmp files for inspection | `false` |
 | `--help` | Show help message | — |
+
+#### Dependency cache
+
+By default the tool reads `.deps/prod.md` and `.deps/dev.md` before calling ClearlyDefined. Any dependency whose **Resolved CQs** column is non-empty (contains a `clearlydefined` link or a CQ number) is considered already resolved and is **skipped** — only new or previously unresolved dependencies are sent to the API. This dramatically reduces API calls for projects with stable dependency trees.
+
+Use `--recheck` to force a full re-query of all dependencies and regenerate the files from scratch.
 
 #### Downloading the Eclipse Dash JAR
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ npx @eclipse-che/license-tool --jar /path/to/dash-licenses.jar
 | `--batch <n>` | Batch size for ClearlyDefined API requests | `500` |
 | `--harvest` | Request harvest for unresolved deps from ClearlyDefined | `false` |
 | `--recheck` | Bypass the `.deps/` cache and re-query ClearlyDefined for every dependency | `false` |
+| `--post-timeout <ms>` | Timeout for batch POST `/definitions` requests | `10000` ms |
+| `--get-timeout <ms>` | Timeout for individual GET `/definitions/{id}` requests | `5000` ms |
 | `--jar <path>` | Path to Eclipse `dash-licenses.jar` for fallback on unresolved dev deps | — |
 | `--debug` | Copy tmp files for inspection | `false` |
 | `--help` | Show help message | — |

--- a/package-lock.json
+++ b/package-lock.json
@@ -5267,9 +5267,9 @@
       ]
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -9112,7 +9112,7 @@
         "@paralleldrive/cuid2": "^2.2.2",
         "dezalgo": "^1.0.4",
         "once": "^1.4.0",
-        "qs": "6.14.2"
+        "qs": "6.15.2"
       }
     },
     "fs.realpath": {
@@ -10459,9 +10459,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "requires": {
         "side-channel": "^1.1.0"
@@ -10832,7 +10832,7 @@
         "formidable": "^2.1.2",
         "methods": "^1.1.2",
         "mime": "2.6.0",
-        "qs": "6.14.2",
+        "qs": "6.15.2",
         "semver": "^7.3.8"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "minimatch@3": "3.1.5",
     "minimatch@9": "9.0.9",
     "terser-webpack-plugin": "5.4.0",
-    "qs": "6.14.2",
+    "qs": "6.15.2",
     "lodash": "4.18.1"
   }
 }

--- a/src/backends/clearlydefined-backend.ts
+++ b/src/backends/clearlydefined-backend.ts
@@ -336,62 +336,72 @@ export class ClearlyDefinedBackend implements LicenseBackend {
    * Only processes dependencies with source 'notfound' or 'error'.
    * Uses batched concurrency to avoid overwhelming the API.
    */
+  /**
+   * Two-phase harvest:
+   *
+   * Phase 1 — check (awaited, batched):
+   *   Query GET /harvest/{id} for every unresolved dependency to see which
+   *   ones have already been harvested by a previous run.
+   *
+   * Phase 2 — request (fire-and-forget):
+   *   POST /harvest for the remaining ones without awaiting the responses.
+   *   ClearlyDefined queues the job server-side; the HTTP response only
+   *   acknowledges receipt and carries no useful data, so there is no reason
+   *   to block on it.  Errors are logged at debug level and the caller
+   *   returns immediately.
+   */
   private async processHarvest(results: DepResult[]): Promise<void> {
     const notfound = results.filter(r => r.source === 'notfound' || r.source === 'error');
-    if (notfound.length === 0) {
-      return;
-    }
+    if (notfound.length === 0) return;
 
     logger.info(`Checking harvest status for ${notfound.length} unresolved dependencies...`);
 
+    // ── Phase 1: check (await all GET requests in batches) ──────────────────
     let alreadyHarvested = 0;
-    let harvestRequested = 0;
-    let harvestFailed = 0;
-
-    // Process harvest requests with controlled concurrency (same as GET_CONCURRENCY)
+    const toRequest: DepResult[] = [];
     const HARVEST_CONCURRENCY = GET_CONCURRENCY;
 
     for (let i = 0; i < notfound.length; i += HARVEST_CONCURRENCY) {
       const batch = notfound.slice(i, i + HARVEST_CONCURRENCY);
 
-      const batchResults = await Promise.all(
+      const checkResults = await Promise.all(
         batch.map(async (dep) => {
           try {
-            // Check if already harvested
             const harvested = await checkHarvested(dep.id, this.getTimeoutMs);
-
             if (harvested.length > 0) {
               logger.debug(`${dep.id}: already harvested (${harvested.length} tools)`);
-              return { status: 'already-harvested' };
+              return { dep, needsRequest: false };
             }
-
-            // Request harvest
-            logger.info(`${dep.id}: requesting harvest...`);
-            await requestHarvest(dep.id, this.getTimeoutMs);
-            return { status: 'requested' };
+            return { dep, needsRequest: true };
           } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
-            logger.debug(`${dep.id}: harvest request failed - ${errorMessage}`);
-            return { status: 'failed' };
+            const msg = error instanceof Error ? error.message : String(error);
+            logger.debug(`${dep.id}: harvest check failed - ${msg}`);
+            return { dep, needsRequest: true };
           }
         })
       );
 
-      // Aggregate results from this batch
-      for (const result of batchResults) {
-        if (result.status === 'already-harvested') alreadyHarvested++;
-        else if (result.status === 'requested') harvestRequested++;
-        else if (result.status === 'failed') harvestFailed++;
+      for (const { dep, needsRequest } of checkResults) {
+        if (needsRequest) toRequest.push(dep);
+        else alreadyHarvested++;
       }
 
-      // Small delay between batches to avoid overwhelming the API
       if (i + HARVEST_CONCURRENCY < notfound.length) {
         await sleep(GET_BATCH_DELAY_MS);
       }
     }
 
-    if (harvestRequested > 0) {
-      logger.info(`Harvest requested for ${harvestRequested} dependencies (${alreadyHarvested} already harvested, ${harvestFailed} failed)`);
+    // ── Phase 2: request (fire-and-forget POST) ──────────────────────────────
+    for (const dep of toRequest) {
+      logger.info(`${dep.id}: requesting harvest...`);
+      requestHarvest(dep.id, this.getTimeoutMs).catch((error) => {
+        const msg = error instanceof Error ? error.message : String(error);
+        logger.debug(`${dep.id}: harvest POST failed - ${msg}`);
+      });
+    }
+
+    if (toRequest.length > 0) {
+      logger.info(`Harvest requested for ${toRequest.length} dependencies (${alreadyHarvested} already harvested)`);
       logger.info('Note: Harvested data may take several minutes to process. Re-run the tool later to check for updates.');
     } else if (alreadyHarvested > 0) {
       logger.info(`All ${alreadyHarvested} unresolved dependencies are already being harvested`);

--- a/src/backends/clearlydefined-backend.ts
+++ b/src/backends/clearlydefined-backend.ts
@@ -51,7 +51,7 @@ export class ClearlyDefinedBackend implements LicenseBackend {
   private readonly useBatchAPI: boolean;
 
   constructor(options?: {
-    /** Timeout for batch POST /definitions requests (default: 10 000 ms). */
+    /** Timeout for batch POST /definitions requests (default: 30 000 ms). */
     postTimeoutMs?: number;
     /** Timeout for individual GET /definitions/{id} requests (default: 5 000 ms). */
     getTimeoutMs?: number;

--- a/src/backends/clearlydefined-backend.ts
+++ b/src/backends/clearlydefined-backend.ts
@@ -23,10 +23,18 @@ const POST_BATCH_SIZE = 100;
 const POST_CONCURRENCY = 2;
 /** Delay between POST batches (ms) */
 const POST_BATCH_DELAY_MS = 500;
-/** Default timeout for batch POST requests (ms) */
-const DEFAULT_POST_TIMEOUT_MS = 10000;
+/**
+ * Default timeout for batch POST /definitions requests (ms).
+ * ClearlyDefined batch POSTs occasionally take 15-25 s; 30 s gives enough
+ * headroom without waiting forever before falling back to GET.
+ */
+const DEFAULT_POST_TIMEOUT_MS = 30000;
 /** Default timeout for individual GET requests (ms) */
 const DEFAULT_GET_TIMEOUT_MS = 5000;
+/** Number of times to retry a failed batch POST before falling back to GET */
+const POST_RETRY_COUNT = 1;
+/** Delay before retrying a failed batch POST (ms) */
+const POST_RETRY_DELAY_MS = 2000;
 
 /** Legacy: Concurrency limit for individual GET requests */
 const GET_CONCURRENCY = 8;
@@ -170,75 +178,70 @@ export class ClearlyDefinedBackend implements LicenseBackend {
   /**
    * Fetch multiple definitions using POST /definitions
    */
+  /**
+   * Fetch a batch of coordinates via POST /definitions.
+   * Retries POST_RETRY_COUNT times on failure before falling back to
+   * individual GET requests.
+   */
   private async fetchBatch(coordinates: string[]): Promise<DepResult[]> {
     const startTime = Date.now();
     const url = 'https://api.clearlydefined.io/definitions';
 
-    try {
-      logger.request('POST', `${url} (${coordinates.length} coordinates)`);
-
-      const batchResponse = await fetchDefinitionsBatch(coordinates, this.postTimeoutMs);
-      const duration = Date.now() - startTime;
-
-      logger.response(200, url, duration);
-
-      const results: DepResult[] = [];
-      for (const coordinate of coordinates) {
-        const def = batchResponse[coordinate];
-
-        // Handle missing or empty definitions
-        if (!def || !def.licensed) {
-          logger.debug(`${coordinate}: not found or no license data`);
-          results.push({
-            id: coordinate,
-            license: '',
-            status: 'restricted',
-            source: 'notfound'
-          });
-          continue;
-        }
-
-        const license = extractLicense(def);
-        if (!license) {
-          results.push({
-            id: coordinate,
-            license: '',
-            status: 'restricted',
-            source: 'notfound'
-          });
-          continue;
-        }
-
-        const approved = isLicenseApproved(license);
-        logger.debug(`${coordinate}: ${license} → ${approved ? 'approved' : 'restricted'}`);
-
-        results.push({
-          id: coordinate,
-          license,
-          status: approved ? 'approved' : 'restricted',
-          source: 'clearlydefined'
-        });
+    for (let attempt = 0; attempt <= POST_RETRY_COUNT; attempt++) {
+      if (attempt > 0) {
+        logger.info(`Retrying batch POST (attempt ${attempt + 1}/${POST_RETRY_COUNT + 1}) after ${POST_RETRY_DELAY_MS} ms...`);
+        await sleep(POST_RETRY_DELAY_MS);
       }
-
-      return results;
-    } catch (error) {
-      const duration = Date.now() - startTime;
-      logger.response(500, url, duration);
-      logger.warn(`Batch POST failed: ${error}`);
-      logger.info(`Falling back to individual GET requests for ${coordinates.length} coordinates`);
-
-      // Fallback: retry each coordinate individually using GET with concurrency limit
-      const fallbackResults: DepResult[] = [];
-      for (let i = 0; i < coordinates.length; i += GET_CONCURRENCY) {
-        const batch = coordinates.slice(i, i + GET_CONCURRENCY);
-        const batchResults = await Promise.all(
-          batch.map(id => this.fetchOne(id))
-        );
-        fallbackResults.push(...batchResults);
+      try {
+        logger.request('POST', `${url} (${coordinates.length} coordinates)`);
+        const batchResponse = await fetchDefinitionsBatch(coordinates, this.postTimeoutMs);
+        const duration = Date.now() - startTime;
+        logger.response(200, url, duration);
+        return this.parseBatchResponse(coordinates, batchResponse);
+      } catch (err) {
+        logger.warn(`Batch POST failed (attempt ${attempt + 1}/${POST_RETRY_COUNT + 1}): ${err}`);
       }
-
-      return fallbackResults;
     }
+
+    // All POST attempts exhausted — fall back to individual GETs.
+    logger.info(`Falling back to individual GET requests for ${coordinates.length} coordinates`);
+    const fallbackResults: DepResult[] = [];
+    for (let i = 0; i < coordinates.length; i += GET_CONCURRENCY) {
+      const batch = coordinates.slice(i, i + GET_CONCURRENCY);
+      const batchResults = await Promise.all(batch.map(id => this.fetchOne(id)));
+      fallbackResults.push(...batchResults);
+    }
+    return fallbackResults;
+  }
+
+  /** Parse a batch POST response into DepResult entries. */
+  private parseBatchResponse(
+    coordinates: string[],
+    batchResponse: Record<string, import('./clearlydefined-client').ClearlyDefinedDefinition>,
+  ): DepResult[] {
+    const results: DepResult[] = [];
+    for (const coordinate of coordinates) {
+      const def = batchResponse[coordinate];
+      if (!def || !def.licensed) {
+        logger.debug(`${coordinate}: not found or no license data`);
+        results.push({ id: coordinate, license: '', status: 'restricted', source: 'notfound' });
+        continue;
+      }
+      const license = extractLicense(def);
+      if (!license) {
+        results.push({ id: coordinate, license: '', status: 'restricted', source: 'notfound' });
+        continue;
+      }
+      const approved = isLicenseApproved(license);
+      logger.debug(`${coordinate}: ${license} → ${approved ? 'approved' : 'restricted'}`);
+      results.push({
+        id: coordinate,
+        license,
+        status: approved ? 'approved' : 'restricted',
+        source: 'clearlydefined',
+      });
+    }
+    return results;
   }
 
   private async fetchOne(clearlyDefinedId: string, maxRetries = 3): Promise<DepResult> {

--- a/src/backends/clearlydefined-backend.ts
+++ b/src/backends/clearlydefined-backend.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { fetchDefinition, fetchDefinitionsBatch, extractLicense, checkHarvested, requestHarvest } from './clearlydefined-client';
+import { fetchDefinition, fetchDefinitionsBatch, extractLicense } from './clearlydefined-client';
 import { isLicenseApproved } from './license-policy';
 import { toClearlyDefinedId } from './coordinate-utils';
 import { sleep } from '../helpers/utils';
@@ -41,7 +41,6 @@ export class ClearlyDefinedBackend implements LicenseBackend {
   private readonly postTimeoutMs: number;
   private readonly getTimeoutMs: number;
   private readonly useBatchAPI: boolean;
-  private readonly enableHarvest: boolean;
 
   constructor(options?: {
     /** Timeout for batch POST /definitions requests (default: 10 000 ms). */
@@ -51,12 +50,10 @@ export class ClearlyDefinedBackend implements LicenseBackend {
     /** @deprecated Use postTimeoutMs / getTimeoutMs instead. Applied to GET requests when getTimeoutMs is absent. */
     timeoutMs?: number;
     useBatchAPI?: boolean;
-    enableHarvest?: boolean;
   }) {
     this.postTimeoutMs = options?.postTimeoutMs ?? DEFAULT_POST_TIMEOUT_MS;
     this.getTimeoutMs = options?.getTimeoutMs ?? options?.timeoutMs ?? DEFAULT_GET_TIMEOUT_MS;
     this.useBatchAPI = options?.useBatchAPI ?? true;
-    this.enableHarvest = options?.enableHarvest ?? false;
   }
 
   async processBatch(deps: string[]): Promise<string[]> {
@@ -88,11 +85,6 @@ export class ClearlyDefinedBackend implements LicenseBackend {
       : await this.processBatchGET(ids);
 
     results.push(...fetchedResults);
-
-    // If harvest is enabled, check and request harvest for notfound dependencies
-    if (this.enableHarvest) {
-      await this.processHarvest(results);
-    }
 
     const duration = Date.now() - startTime;
     const approved = results.filter(r => r.status === 'approved').length;
@@ -329,83 +321,6 @@ export class ClearlyDefinedBackend implements LicenseBackend {
       status: 'restricted',
       source: 'error'
     };
-  }
-
-  /**
-   * Check and request harvest for dependencies that were not found.
-   * Only processes dependencies with source 'notfound' or 'error'.
-   * Uses batched concurrency to avoid overwhelming the API.
-   */
-  /**
-   * Two-phase harvest:
-   *
-   * Phase 1 — check (awaited, batched):
-   *   Query GET /harvest/{id} for every unresolved dependency to see which
-   *   ones have already been harvested by a previous run.
-   *
-   * Phase 2 — request (fire-and-forget):
-   *   POST /harvest for the remaining ones without awaiting the responses.
-   *   ClearlyDefined queues the job server-side; the HTTP response only
-   *   acknowledges receipt and carries no useful data, so there is no reason
-   *   to block on it.  Errors are logged at debug level and the caller
-   *   returns immediately.
-   */
-  private async processHarvest(results: DepResult[]): Promise<void> {
-    const notfound = results.filter(r => r.source === 'notfound' || r.source === 'error');
-    if (notfound.length === 0) return;
-
-    logger.info(`Checking harvest status for ${notfound.length} unresolved dependencies...`);
-
-    // ── Phase 1: check (await all GET requests in batches) ──────────────────
-    let alreadyHarvested = 0;
-    const toRequest: DepResult[] = [];
-    const HARVEST_CONCURRENCY = GET_CONCURRENCY;
-
-    for (let i = 0; i < notfound.length; i += HARVEST_CONCURRENCY) {
-      const batch = notfound.slice(i, i + HARVEST_CONCURRENCY);
-
-      const checkResults = await Promise.all(
-        batch.map(async (dep) => {
-          try {
-            const harvested = await checkHarvested(dep.id, this.getTimeoutMs);
-            if (harvested.length > 0) {
-              logger.debug(`${dep.id}: already harvested (${harvested.length} tools)`);
-              return { dep, needsRequest: false };
-            }
-            return { dep, needsRequest: true };
-          } catch (error) {
-            const msg = error instanceof Error ? error.message : String(error);
-            logger.debug(`${dep.id}: harvest check failed - ${msg}`);
-            return { dep, needsRequest: true };
-          }
-        })
-      );
-
-      for (const { dep, needsRequest } of checkResults) {
-        if (needsRequest) toRequest.push(dep);
-        else alreadyHarvested++;
-      }
-
-      if (i + HARVEST_CONCURRENCY < notfound.length) {
-        await sleep(GET_BATCH_DELAY_MS);
-      }
-    }
-
-    // ── Phase 2: request (fire-and-forget POST) ──────────────────────────────
-    for (const dep of toRequest) {
-      logger.info(`${dep.id}: requesting harvest...`);
-      requestHarvest(dep.id, this.getTimeoutMs).catch((error) => {
-        const msg = error instanceof Error ? error.message : String(error);
-        logger.debug(`${dep.id}: harvest POST failed - ${msg}`);
-      });
-    }
-
-    if (toRequest.length > 0) {
-      logger.info(`Harvest requested for ${toRequest.length} dependencies (${alreadyHarvested} already harvested)`);
-      logger.info('Note: Harvested data may take several minutes to process. Re-run the tool later to check for updates.');
-    } else if (alreadyHarvested > 0) {
-      logger.info(`All ${alreadyHarvested} unresolved dependencies are already being harvested`);
-    }
   }
 
   private toDependenciesLine(r: DepResult): string {

--- a/src/backends/clearlydefined-backend.ts
+++ b/src/backends/clearlydefined-backend.ts
@@ -210,6 +210,9 @@ export class ClearlyDefinedBackend implements LicenseBackend {
       const batch = coordinates.slice(i, i + GET_CONCURRENCY);
       const batchResults = await Promise.all(batch.map(id => this.fetchOne(id)));
       fallbackResults.push(...batchResults);
+      if (i + GET_CONCURRENCY < coordinates.length) {
+        await sleep(GET_BATCH_DELAY_MS);
+      }
     }
     return fallbackResults;
   }

--- a/src/backends/clearlydefined-backend.ts
+++ b/src/backends/clearlydefined-backend.ts
@@ -23,8 +23,10 @@ const POST_BATCH_SIZE = 100;
 const POST_CONCURRENCY = 2;
 /** Delay between POST batches (ms) */
 const POST_BATCH_DELAY_MS = 500;
-/** Timeout for batch POST requests (ms) - longer than individual GETs */
-const POST_TIMEOUT_MS = 60000;
+/** Default timeout for batch POST requests (ms) */
+const DEFAULT_POST_TIMEOUT_MS = 10000;
+/** Default timeout for individual GET requests (ms) */
+const DEFAULT_GET_TIMEOUT_MS = 5000;
 
 /** Legacy: Concurrency limit for individual GET requests */
 const GET_CONCURRENCY = 8;
@@ -36,14 +38,25 @@ const GET_BATCH_DELAY_MS = 200;
  * Fetches license data from api.clearlydefined.io and applies approval policy.
  */
 export class ClearlyDefinedBackend implements LicenseBackend {
-  private readonly timeoutMs: number;
+  private readonly postTimeoutMs: number;
+  private readonly getTimeoutMs: number;
   private readonly useBatchAPI: boolean;
   private readonly enableHarvest: boolean;
 
-  constructor(options?: { timeoutMs?: number; useBatchAPI?: boolean; enableHarvest?: boolean }) {
-    this.timeoutMs = options?.timeoutMs ?? 30000;
-    this.useBatchAPI = options?.useBatchAPI ?? true; // Default to batch POST API
-    this.enableHarvest = options?.enableHarvest ?? false; // Default: harvest disabled
+  constructor(options?: {
+    /** Timeout for batch POST /definitions requests (default: 10 000 ms). */
+    postTimeoutMs?: number;
+    /** Timeout for individual GET /definitions/{id} requests (default: 5 000 ms). */
+    getTimeoutMs?: number;
+    /** @deprecated Use postTimeoutMs / getTimeoutMs instead. Applied to GET requests when getTimeoutMs is absent. */
+    timeoutMs?: number;
+    useBatchAPI?: boolean;
+    enableHarvest?: boolean;
+  }) {
+    this.postTimeoutMs = options?.postTimeoutMs ?? DEFAULT_POST_TIMEOUT_MS;
+    this.getTimeoutMs = options?.getTimeoutMs ?? options?.timeoutMs ?? DEFAULT_GET_TIMEOUT_MS;
+    this.useBatchAPI = options?.useBatchAPI ?? true;
+    this.enableHarvest = options?.enableHarvest ?? false;
   }
 
   async processBatch(deps: string[]): Promise<string[]> {
@@ -172,7 +185,7 @@ export class ClearlyDefinedBackend implements LicenseBackend {
     try {
       logger.request('POST', `${url} (${coordinates.length} coordinates)`);
 
-      const batchResponse = await fetchDefinitionsBatch(coordinates, POST_TIMEOUT_MS);
+      const batchResponse = await fetchDefinitionsBatch(coordinates, this.postTimeoutMs);
       const duration = Date.now() - startTime;
 
       logger.response(200, url, duration);
@@ -249,7 +262,7 @@ export class ClearlyDefinedBackend implements LicenseBackend {
           logger.debug(`Retry ${attempt}/${maxRetries} for ${clearlyDefinedId}`);
         }
 
-        const def = await fetchDefinition(clearlyDefinedId, this.timeoutMs);
+        const def = await fetchDefinition(clearlyDefinedId, this.getTimeoutMs);
         const duration = Date.now() - startTime;
 
         const license = def ? extractLicense(def) : '';
@@ -345,7 +358,7 @@ export class ClearlyDefinedBackend implements LicenseBackend {
         batch.map(async (dep) => {
           try {
             // Check if already harvested
-            const harvested = await checkHarvested(dep.id, this.timeoutMs);
+            const harvested = await checkHarvested(dep.id, this.getTimeoutMs);
 
             if (harvested.length > 0) {
               logger.debug(`${dep.id}: already harvested (${harvested.length} tools)`);
@@ -354,7 +367,7 @@ export class ClearlyDefinedBackend implements LicenseBackend {
 
             // Request harvest
             logger.info(`${dep.id}: requesting harvest...`);
-            await requestHarvest(dep.id, this.timeoutMs);
+            await requestHarvest(dep.id, this.getTimeoutMs);
             return { status: 'requested' };
           } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);

--- a/src/backends/harvest.ts
+++ b/src/backends/harvest.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { checkHarvested, requestHarvest } from './clearlydefined-client';
+import { identifierToCoordinate } from '../helpers/utils';
+import { logger } from '../helpers/logger';
+import { sleep } from '../helpers/utils';
+
+const CHECK_CONCURRENCY = 8;
+const CHECK_DELAY_MS = 200;
+
+/**
+ * Check which of the given package identifiers still need a harvest request,
+ * then fire POST /harvest for each one (fire-and-forget).
+ *
+ * Only identifiers that can be converted to a ClearlyDefined coordinate
+ * (npm/npmjs/…) are processed.  Others are silently skipped.
+ *
+ * This function returns immediately after dispatching the POST requests —
+ * it does not wait for the server to finish harvesting.
+ *
+ * @param identifiers  Package identifiers in the form "pkg@version" or
+ *                     "@scope/pkg@version".  These are the direct-unresolved
+ *                     deps from problems.md.
+ * @param getTimeoutMs Timeout for the GET /harvest check requests (ms).
+ */
+export async function triggerHarvestAsync(
+  identifiers: string[],
+  getTimeoutMs: number,
+): Promise<void> {
+  // Convert identifiers to ClearlyDefined coordinates; skip any that don't map.
+  const coordEntries = identifiers
+    .map(id => ({ id, coord: identifierToCoordinate(id) }))
+    .filter(e => Boolean(e.coord));
+
+  if (coordEntries.length === 0) return;
+
+  logger.info(`Checking harvest status for ${coordEntries.length} unresolved dependencies...`);
+
+  // ── Phase 1: check (await GET /harvest/{coord} in parallel batches) ────────
+  let alreadyHarvested = 0;
+  const toRequest: string[] = [];
+
+  for (let i = 0; i < coordEntries.length; i += CHECK_CONCURRENCY) {
+    const batch = coordEntries.slice(i, i + CHECK_CONCURRENCY);
+
+    const checkResults = await Promise.all(
+      batch.map(async ({ id, coord }) => {
+        try {
+          const harvested = await checkHarvested(coord, getTimeoutMs);
+          if (harvested.length > 0) {
+            logger.debug(`${id}: already harvested (${harvested.length} tools)`);
+            return { id, coord, needsRequest: false };
+          }
+          return { id, coord, needsRequest: true };
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          logger.debug(`${id}: harvest check failed - ${msg}`);
+          return { id, coord, needsRequest: true };
+        }
+      })
+    );
+
+    for (const { id, coord, needsRequest } of checkResults) {
+      if (needsRequest) {
+        toRequest.push(coord);
+        logger.info(`${id}: requesting harvest...`);
+      } else {
+        alreadyHarvested++;
+      }
+    }
+
+    if (i + CHECK_CONCURRENCY < coordEntries.length) {
+      await sleep(CHECK_DELAY_MS);
+    }
+  }
+
+  // ── Phase 2: request (fire-and-forget POST /harvest) ─────────────────────
+  for (const coord of toRequest) {
+    requestHarvest(coord, getTimeoutMs).catch((error) => {
+      const msg = error instanceof Error ? error.message : String(error);
+      logger.debug(`harvest POST failed for ${coord} - ${msg}`);
+    });
+  }
+
+  if (toRequest.length > 0) {
+    logger.info(
+      `Harvest requested for ${toRequest.length} dependencies` +
+      (alreadyHarvested > 0 ? ` (${alreadyHarvested} already harvested)` : ''),
+    );
+    logger.info('Note: Harvested data may take several minutes to process. Re-run the tool later to check for updates.');
+  } else if (alreadyHarvested > 0) {
+    logger.info(`All ${alreadyHarvested} unresolved dependencies are already being harvested`);
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ function parseArgs(): {
   check: boolean;
   debug: boolean;
   harvest: boolean;
+  recheck: boolean;
   jarPath?: string;
 } {
   const args = process.argv.slice(2);
@@ -27,6 +28,7 @@ function parseArgs(): {
   let check = false;
   let debug = false;
   let harvest = false;
+  let recheck = false;
   let jarPath: string | undefined;
 
   for (let i = 0; i < args.length; i++) {
@@ -40,14 +42,26 @@ Options:
   --batch <n>    Batch size (default: 500)
   --debug        Copy tmp files for inspection
   --harvest      Request harvest for unresolved dependencies from ClearlyDefined
+  --recheck      Bypass the .deps/prod.md + .deps/dev.md cache and re-query
+                 ClearlyDefined for every dependency (default: cache is used)
   --jar <path>   Optional path to Eclipse dash-licenses.jar for fallback on unresolved dev deps
   --help         Show this message
+
+Cache behaviour (default):
+  On each run the tool reads .deps/prod.md and .deps/dev.md. Any dependency
+  that already has a non-empty "Resolved CQs" column (e.g. a clearlydefined
+  link) is considered resolved and is skipped — only new or previously
+  unresolved dependencies are sent to ClearlyDefined. This dramatically
+  reduces API calls for projects with stable dependency trees.
+
+  Use --recheck to force a full re-query of all dependencies.
 
 Examples:
   npx license-tool
   npx license-tool --check --batch 200
   npx license-tool /path/to/project
   npx license-tool --harvest
+  npx license-tool --recheck
   npx license-tool --jar /path/to/dash-licenses.jar
 `);
       process.exit(0);
@@ -55,6 +69,7 @@ Examples:
     if (args[i] === '--check') check = true;
     else if (args[i] === '--debug') debug = true;
     else if (args[i] === '--harvest') harvest = true;
+    else if (args[i] === '--recheck') recheck = true;
     else if (args[i] === '--batch' && args[i + 1]) {
       batchSize = parseInt(args[++i], 10);
       if (isNaN(batchSize)) batchSize = 500;
@@ -66,8 +81,8 @@ Examples:
   }
 
   return jarPath
-    ? { projectPath, batchSize, check, debug, harvest, jarPath }
-    : { projectPath, batchSize, check, debug, harvest };
+    ? { projectPath, batchSize, check, debug, harvest, recheck, jarPath }
+    : { projectPath, batchSize, check, debug, harvest, recheck };
 }
 
 async function main(): Promise<void> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,8 @@ function parseArgs(): {
   debug: boolean;
   harvest: boolean;
   recheck: boolean;
+  postTimeoutMs?: number;
+  getTimeoutMs?: number;
   jarPath?: string;
 } {
   const args = process.argv.slice(2);
@@ -29,6 +31,8 @@ function parseArgs(): {
   let debug = false;
   let harvest = false;
   let recheck = false;
+  let postTimeoutMs: number | undefined;
+  let getTimeoutMs: number | undefined;
   let jarPath: string | undefined;
 
   for (let i = 0; i < args.length; i++) {
@@ -42,10 +46,12 @@ Options:
   --batch <n>    Batch size (default: 500)
   --debug        Copy tmp files for inspection
   --harvest      Request harvest for unresolved dependencies from ClearlyDefined
-  --recheck      Bypass the .deps/prod.md + .deps/dev.md cache and re-query
-                 ClearlyDefined for every dependency (default: cache is used)
-  --jar <path>   Optional path to Eclipse dash-licenses.jar for fallback on unresolved dev deps
-  --help         Show this message
+  --recheck             Bypass the .deps/prod.md + .deps/dev.md cache and re-query
+                        ClearlyDefined for every dependency (default: cache is used)
+  --post-timeout <ms>   Timeout for batch POST /definitions requests (default: 10000 ms)
+  --get-timeout <ms>    Timeout for individual GET /definitions/{id} requests (default: 5000 ms)
+  --jar <path>          Optional path to Eclipse dash-licenses.jar for fallback on unresolved dev deps
+  --help                Show this message
 
 Cache behaviour (default):
   On each run the tool reads .deps/prod.md and .deps/dev.md. Any dependency
@@ -62,6 +68,7 @@ Examples:
   npx license-tool /path/to/project
   npx license-tool --harvest
   npx license-tool --recheck
+  npx license-tool --post-timeout 20000 --get-timeout 10000
   npx license-tool --jar /path/to/dash-licenses.jar
 `);
       process.exit(0);
@@ -70,7 +77,13 @@ Examples:
     else if (args[i] === '--debug') debug = true;
     else if (args[i] === '--harvest') harvest = true;
     else if (args[i] === '--recheck') recheck = true;
-    else if (args[i] === '--batch' && args[i + 1]) {
+    else if (args[i] === '--post-timeout' && args[i + 1]) {
+      const v = parseInt(args[++i], 10);
+      if (!isNaN(v) && v > 0) postTimeoutMs = v;
+    } else if (args[i] === '--get-timeout' && args[i + 1]) {
+      const v = parseInt(args[++i], 10);
+      if (!isNaN(v) && v > 0) getTimeoutMs = v;
+    } else if (args[i] === '--batch' && args[i + 1]) {
       batchSize = parseInt(args[++i], 10);
       if (isNaN(batchSize)) batchSize = 500;
     } else if (args[i] === '--jar' && args[i + 1]) {
@@ -80,9 +93,14 @@ Examples:
     }
   }
 
+  const base = { projectPath, batchSize, check, debug, harvest, recheck };
+  const timeouts = {
+    ...(postTimeoutMs !== undefined ? { postTimeoutMs } : {}),
+    ...(getTimeoutMs !== undefined ? { getTimeoutMs } : {}),
+  };
   return jarPath
-    ? { projectPath, batchSize, check, debug, harvest, recheck, jarPath }
-    : { projectPath, batchSize, check, debug, harvest, recheck };
+    ? { ...base, ...timeouts, jarPath }
+    : { ...base, ...timeouts };
 }
 
 async function main(): Promise<void> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,7 +48,7 @@ Options:
   --harvest      Request harvest for unresolved dependencies from ClearlyDefined
   --recheck             Bypass the .deps/prod.md + .deps/dev.md cache and re-query
                         ClearlyDefined for every dependency (default: cache is used)
-  --post-timeout <ms>   Timeout for batch POST /definitions requests (default: 10000 ms)
+  --post-timeout <ms>   Timeout for batch POST /definitions requests (default: 30000 ms)
   --get-timeout <ms>    Timeout for individual GET /definitions/{id} requests (default: 5000 ms)
   --jar <path>          Optional path to Eclipse dash-licenses.jar for fallback on unresolved dev deps
   --help                Show this message

--- a/src/document/__tests__/index.test.ts
+++ b/src/document/__tests__/index.test.ts
@@ -186,28 +186,29 @@ describe('DocumentGenerator', () => {
       ]);
       const allLicenses: LicenseMap = new Map([
         ['react@18.0.0', { License: 'MIT' }],
-        ['lodash@4.17.21', { License: 'MIT', URL: 'https://lodash.com' }]
+        ['lodash@4.17.21', { License: 'MIT' }]
       ]);
-      
+
       const result = DocumentGenerator.arrayToDocument(title, depsArray, depToCQ, allLicenses);
-      
+
       expect(result).toContain('# Production dependencies');
       expect(result).toContain('| Packages | License | Resolved CQs |');
-      expect(result).toContain('| [`lodash@4.17.21`](https://lodash.com) | MIT | IP team approval |');
+      expect(result).toContain('| `lodash@4.17.21` | MIT | IP team approval |');
       expect(result).toContain('| `react@18.0.0` | MIT | clearlydefined |');
     });
 
-    test('should handle dependencies with URLs', () => {
+    test('should render package name as plain backtick code (no hyperlink)', () => {
       const title = 'Test dependencies';
       const depsArray = ['test-package@1.0.0'];
       const depToCQ: DependencyMap = new Map([['test-package@1.0.0', 'approved']]);
       const allLicenses: LicenseMap = new Map([
-        ['test-package@1.0.0', { License: 'MIT', URL: 'https://example.com' }]
+        ['test-package@1.0.0', { License: 'MIT' }]
       ]);
-      
+
       const result = DocumentGenerator.arrayToDocument(title, depsArray, depToCQ, allLicenses);
-      
-      expect(result).toContain('[`test-package@1.0.0`](https://example.com)');
+
+      expect(result).toContain('| `test-package@1.0.0` | MIT | approved |');
+      expect(result).not.toContain('](');
     });
 
     test('should handle unresolved dependencies', () => {

--- a/src/document/__tests__/yarn-real-data.test.ts
+++ b/src/document/__tests__/yarn-real-data.test.ts
@@ -120,13 +120,9 @@ describe('Yarn Real Data Integration Tests', () => {
         const licenses = JSON.parse(yarnDepsInfo.substring(tableStartIndex));
         const { head, body } = licenses.data;
         body.forEach((libInfo: string[]) => {
-          const url = libInfo[head.indexOf('URL')];
           const licenseInfo: LicenseInfo = {
             License: libInfo[head.indexOf('License')]
           };
-          if (url && url !== 'Unknown') {
-            licenseInfo.URL = url;
-          }
           allLicenses.set(`${libInfo[head.indexOf('Name')]}@${libInfo[head.indexOf('Version')]}`, licenseInfo);
         });
       }

--- a/src/document/index.ts
+++ b/src/document/index.ts
@@ -136,9 +136,16 @@ export class DependencyParser {
               identifier = `${name}@${version}`;
             }
             
-            allLicenses.set(identifier, {
-              License: license ? license.trim() : ''
-            });
+            // Don't overwrite a real license with 'unknown' or empty —
+            // allLicenses may already have the correct value from node_modules
+            // (extractLicenseInfo). EXCLUDED-cached entries write 'unknown' as
+            // a placeholder; preserve the existing value in that case.
+            const incomingLicense = license ? license.trim() : '';
+            if (incomingLicense && incomingLicense !== 'unknown') {
+              allLicenses.set(identifier, { License: incomingLicense });
+            } else if (!allLicenses.has(identifier)) {
+              allLicenses.set(identifier, { License: incomingLicense });
+            }
           }
         }
       });

--- a/src/document/index.ts
+++ b/src/document/index.ts
@@ -252,11 +252,7 @@ export class DocumentGenerator {
 
     depsArray.sort().forEach(item => {
       const license = allLicenses.has(item) ? allLicenses.get(item)?.License ?? '' : '';
-      let lib = `\`${item}\``;
-      const licenseInfo = allLicenses.get(item);
-      if (licenseInfo?.URL) {
-        lib = `[${lib}](${licenseInfo.URL})`;
-      }
+      const lib = `\`${item}\``;
       let cq = '';
       if (depToCQ.has(item)) {
         cq = depToCQ.get(item) ?? '';

--- a/src/document/index.ts
+++ b/src/document/index.ts
@@ -141,7 +141,7 @@ export class DependencyParser {
             // (extractLicenseInfo). EXCLUDED-cached entries write 'unknown' as
             // a placeholder; preserve the existing value in that case.
             const incomingLicense = license ? license.trim() : '';
-            if (incomingLicense && incomingLicense !== 'unknown') {
+            if (incomingLicense && incomingLicense.toLowerCase() !== 'unknown') {
               allLicenses.set(identifier, { License: incomingLicense });
             } else if (!allLicenses.has(identifier)) {
               allLicenses.set(identifier, { License: incomingLicense });

--- a/src/helpers/__tests__/package-manager-base.test.ts
+++ b/src/helpers/__tests__/package-manager-base.test.ts
@@ -141,6 +141,7 @@ describe('Options interface', () => {
       check: true,
       debug: false,
       harvest: false,
+      recheck: false,
     };
 
     expect(options).toHaveProperty('check');

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -13,7 +13,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { PackageManagerUtils, type FilePaths } from '../utils';
+import { PackageManagerUtils, coordinateToIdentifier, identifierToCoordinate, type FilePaths } from '../utils';
 import type { DependencyMap } from '../../document';
 
 describe('PackageManagerUtils Integration Tests', () => {
@@ -295,6 +295,75 @@ describe('PackageManagerUtils Integration Tests', () => {
       const { prod } = PackageManagerUtils.getDirectPackageNames(tmpDir);
       expect(prod.has('axios')).toBe(true);   // direct
       expect(prod.has('follow-redirects')).toBe(false); // transitive dep of axios
+    });
+  });
+
+  describe('coordinateToIdentifier', () => {
+    test('passes through a plain unscoped identifier unchanged', () => {
+      expect(coordinateToIdentifier('express@4.18.0')).toBe('express@4.18.0');
+    });
+
+    test('passes through a plain scoped identifier unchanged', () => {
+      expect(coordinateToIdentifier('@babel/core@7.0.0')).toBe('@babel/core@7.0.0');
+    });
+
+    test('converts Yarn Berry unscoped format (name@npm:version)', () => {
+      expect(coordinateToIdentifier('express@npm:4.18.0')).toBe('express@4.18.0');
+    });
+
+    test('converts Yarn Berry scoped format (@scope/pkg@npm:version)', () => {
+      expect(coordinateToIdentifier('@babel/core@npm:7.0.0')).toBe('@babel/core@7.0.0');
+    });
+
+    test('converts ClearlyDefined coordinate for unscoped package', () => {
+      expect(coordinateToIdentifier('npm/npmjs/-/express/4.18.0')).toBe('express@4.18.0');
+    });
+
+    test('converts ClearlyDefined coordinate for scoped package', () => {
+      expect(coordinateToIdentifier('npm/npmjs/@babel/core/7.0.0')).toBe('@babel/core@7.0.0');
+    });
+
+    test('returns empty string for malformed input', () => {
+      expect(coordinateToIdentifier('')).toBe('');
+      expect(coordinateToIdentifier('no-version-here')).toBe('');
+    });
+  });
+
+  describe('identifierToCoordinate', () => {
+    test('converts unscoped identifier to ClearlyDefined coordinate', () => {
+      expect(identifierToCoordinate('express@4.18.0')).toBe('npm/npmjs/-/express/4.18.0');
+    });
+
+    test('converts scoped identifier to ClearlyDefined coordinate', () => {
+      expect(identifierToCoordinate('@babel/core@7.0.0')).toBe('npm/npmjs/@babel/core/7.0.0');
+    });
+
+    test('returns empty string when there is no @ separator', () => {
+      expect(identifierToCoordinate('express')).toBe('');
+    });
+
+    test('returns empty string when version part is empty', () => {
+      expect(identifierToCoordinate('express@')).toBe('');
+    });
+
+    test('returns empty string for malformed scoped package without slash (e.g. @scope@1.0.0)', () => {
+      expect(identifierToCoordinate('@scope@1.0.0')).toBe('');
+    });
+
+    test('returns empty string for scoped package with trailing slash only', () => {
+      expect(identifierToCoordinate('@scope/@1.0.0')).toBe('');
+    });
+
+    test('round-trips with coordinateToIdentifier for unscoped package', () => {
+      const identifier = 'lodash@4.17.21';
+      const coordinate = identifierToCoordinate(identifier);
+      expect(coordinateToIdentifier(coordinate)).toBe(identifier);
+    });
+
+    test('round-trips with coordinateToIdentifier for scoped package', () => {
+      const identifier = '@types/node@18.0.0';
+      const coordinate = identifierToCoordinate(identifier);
+      expect(coordinateToIdentifier(coordinate)).toBe(identifier);
     });
   });
 

--- a/src/helpers/chunked-processor.ts
+++ b/src/helpers/chunked-processor.ts
@@ -122,13 +122,18 @@ export class ChunkedDashLicensesProcessor {
       for (const coord of allDependencies) {
         const id = coordinateToIdentifier(coord);
         if (id && cache.has(id)) {
-          // Reconstruct a DEPENDENCIES-format line from the cached entry.
-          // parseDependenciesFile expects ClearlyDefined coordinate format:
-          //   npm/npmjs/@scope/name/version, MIT, approved, clearlydefined
-          // so we convert the identifier back to a coordinate.
           const entry = cache.get(id)!;
           const cdCoord = identifierToCoordinate(id) || coord;
-          cachedLines.push(`${cdCoord}, ${entry.license}, approved, clearlydefined`);
+          if (entry.license) {
+            // Resolved by ClearlyDefined — write as approved so parseDependenciesFile
+            // adds it to depsToCQ with the clearlydefined link.
+            cachedLines.push(`${cdCoord}, ${entry.license}, approved, clearlydefined`);
+          } else {
+            // Sourced from EXCLUDED (transitive dep or manual exclusion, no license).
+            // Write as restricted so parseDependenciesFile ignores it; the dep is
+            // handled by processExcludedDependencies reading the EXCLUDED files.
+            cachedLines.push(`${cdCoord}, unknown, restricted, excluded`);
+          }
         } else {
           depsToQuery.push(coord);
         }

--- a/src/helpers/chunked-processor.ts
+++ b/src/helpers/chunked-processor.ts
@@ -116,6 +116,9 @@ export class ChunkedDashLicensesProcessor {
     const cache = this.options.cachedResolutions;
     let depsToQuery = allDependencies;
     const cachedLines: string[] = [];
+    // EXCLUDED entries whose CQ is a ClearlyDefined link — verify via the API so
+    // they can be auto-removed from EXCLUDED if still approved.
+    const toVerify: string[] = [];
 
     if (cache && cache.size > 0) {
       depsToQuery = [];
@@ -125,21 +128,29 @@ export class ChunkedDashLicensesProcessor {
           const entry = cache.get(id)!;
           const cdCoord = identifierToCoordinate(id) || coord;
           if (entry.license) {
-            // Resolved by ClearlyDefined — write as approved so parseDependenciesFile
-            // adds it to depsToCQ with the clearlydefined link.
+            // Resolved by ClearlyDefined (prod.md/dev.md source) — write as approved.
             cachedLines.push(`${cdCoord}, ${entry.license}, approved, clearlydefined`);
+          } else if (entry.cq.includes('clearlydefined.io')) {
+            // EXCLUDED entry whose CQ is a ClearlyDefined link — send to the API to
+            // confirm it is still approved.  If it comes back approved,
+            // parseDependenciesFile detects it as an "unused exclude" and
+            // processAndGenerateDocuments removes it from the EXCLUDED file.
+            toVerify.push(cdCoord);
           } else {
-            // Sourced from EXCLUDED (transitive dep or manual exclusion, no license).
-            // Write as restricted so parseDependenciesFile ignores it; the dep is
-            // handled by processExcludedDependencies reading the EXCLUDED files.
+            // ecd.che, transitive dependency, or other non-ClearlyDefined exclusion.
+            // Write as restricted; processExcludedDependencies handles it.
             cachedLines.push(`${cdCoord}, unknown, restricted, excluded`);
           }
         } else {
           depsToQuery.push(coord);
         }
       }
-      if (cachedLines.length > 0) {
-        logger.info(`Cache hit: ${cachedLines.length} dependencies skipped (already resolved).`);
+      const directHits = cachedLines.length;
+      if (directHits > 0 || toVerify.length > 0) {
+        const verifyNote = toVerify.length > 0
+          ? ` (verifying ${toVerify.length} EXCLUDED entr${toVerify.length !== 1 ? 'ies' : 'y'} via API)`
+          : '';
+        logger.info(`Cache hit: ${directHits + toVerify.length} dependencies skipped${verifyNote}.`);
       }
       if (depsToQuery.length > 0) {
         // Build a detailed breakdown so the log is actionable.
@@ -173,6 +184,34 @@ export class ChunkedDashLicensesProcessor {
 
         const detail = parts.length > 0 ? ` (${parts.join(', ')})` : '';
         logger.info(`Cache miss: ${depsToQuery.length} dependencies to query${detail}.`);
+      }
+    }
+
+    // Verify EXCLUDED entries that carry a ClearlyDefined CQ link.
+    // Entries confirmed as approved are written with approved status so that
+    // parseDependenciesFile flags them as unused excludes and
+    // processAndGenerateDocuments auto-removes them from the EXCLUDED files.
+    if (toVerify.length > 0) {
+      try {
+        const verifiedLines = await this.backend.processBatch(toVerify);
+        let autoCleanCount = 0;
+        for (const vLine of verifiedLines) {
+          if (vLine.includes(', approved,')) {
+            cachedLines.push(vLine);
+            autoCleanCount++;
+          } else {
+            const vCoord = vLine.split(',')[0].trim();
+            cachedLines.push(`${vCoord}, unknown, restricted, excluded`);
+          }
+        }
+        if (autoCleanCount > 0) {
+          logger.info(`EXCLUDED verify: ${autoCleanCount}/${toVerify.length} entr${autoCleanCount !== 1 ? 'ies' : 'y'} approved — will be removed from EXCLUDED.`);
+        }
+      } catch (err) {
+        logger.warn(`Could not verify EXCLUDED entries: ${getErrorMessage(err)}. Keeping in EXCLUDED.`);
+        for (const coord of toVerify) {
+          cachedLines.push(`${coord}, unknown, restricted, excluded`);
+        }
       }
     }
 

--- a/src/helpers/chunked-processor.ts
+++ b/src/helpers/chunked-processor.ts
@@ -34,8 +34,6 @@ export interface ChunkedProcessorOptions {
   batchSize: number;
   outputFile: string;
   debug?: boolean;
-  /** Enable harvest request for unresolved dependencies */
-  enableHarvest?: boolean;
   maxRetries?: number;
   retryDelayMs?: number;
   /**
@@ -79,7 +77,6 @@ export class ChunkedDashLicensesProcessor {
             options.debug
           )
         : new ClearlyDefinedBackend({
-            enableHarvest: options.enableHarvest ?? false,
             ...(options.postTimeoutMs !== undefined ? { postTimeoutMs: options.postTimeoutMs } : {}),
             ...(options.getTimeoutMs !== undefined ? { getTimeoutMs: options.getTimeoutMs } : {}),
           }));

--- a/src/helpers/chunked-processor.ts
+++ b/src/helpers/chunked-processor.ts
@@ -15,7 +15,7 @@ import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
 import type { LicenseBackend } from '../backends/types';
 import { ClearlyDefinedBackend } from '../backends/clearlydefined-backend';
 import { JarBackend } from '../backends/jar-backend';
-import { sleep, parseNonEmptyLines, getErrorMessage, coordinateToIdentifier } from './utils';
+import { sleep, parseNonEmptyLines, getErrorMessage, coordinateToIdentifier, identifierToCoordinate, type CacheEntry } from './utils';
 import { logger } from './logger';
 
 /** Default maximum number of retry attempts for chunk processing */
@@ -52,12 +52,12 @@ export interface ChunkedProcessorOptions {
   backend?: LicenseBackend;
   /**
    * Pre-resolved cache from existing .deps/prod.md + .deps/dev.md.
-   * Keys are package identifiers (e.g. "express@4.18.0"); values are the
-   * resolved CQ string (e.g. "[clearlydefined](...)").
+   * Keys are package identifiers (e.g. "express@4.18.0"); values carry the
+   * SPDX license and resolved CQ string.
    * Coordinates present in the cache are written directly to the output file
    * without calling the API.  Omit or leave empty to query everything.
    */
-  cachedResolutions?: Map<string, string>;
+  cachedResolutions?: Map<string, CacheEntry>;
 }
 
 export class ChunkedDashLicensesProcessor {
@@ -115,16 +115,13 @@ export class ChunkedDashLicensesProcessor {
       for (const coord of allDependencies) {
         const id = coordinateToIdentifier(coord);
         if (id && cache.has(id)) {
-          // Reconstruct a DEPENDENCIES-format line from the cached CQ value.
-          // Format: coordinate, license, approved, clearlydefined
-          const cq = cache.get(id)!;
-          // Extract license from cq map if we stored it; otherwise use 'unknown'
-          // (processAndGenerateDocuments will read licence from the DEPENDENCIES file)
-          // We emit a minimal valid line — licence will be re-read from ClearlyDefined
-          // data already embedded in the link.  Use 'approved' status.
-          const licenseMatch = cq.match(/\[([A-Za-z0-9\-. +]+)\]/);
-          const license = licenseMatch ? licenseMatch[1] : 'unknown';
-          cachedLines.push(`${coord}, ${license}, approved, clearlydefined`);
+          // Reconstruct a DEPENDENCIES-format line from the cached entry.
+          // parseDependenciesFile expects ClearlyDefined coordinate format:
+          //   npm/npmjs/@scope/name/version, MIT, approved, clearlydefined
+          // so we convert the identifier back to a coordinate.
+          const entry = cache.get(id)!;
+          const cdCoord = identifierToCoordinate(id) || coord;
+          cachedLines.push(`${cdCoord}, ${entry.license}, approved, clearlydefined`);
         } else {
           depsToQuery.push(coord);
         }

--- a/src/helpers/chunked-processor.ts
+++ b/src/helpers/chunked-processor.ts
@@ -15,7 +15,7 @@ import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
 import type { LicenseBackend } from '../backends/types';
 import { ClearlyDefinedBackend } from '../backends/clearlydefined-backend';
 import { JarBackend } from '../backends/jar-backend';
-import { sleep, parseNonEmptyLines, getErrorMessage } from './utils';
+import { sleep, parseNonEmptyLines, getErrorMessage, coordinateToIdentifier } from './utils';
 import { logger } from './logger';
 
 /** Default maximum number of retry attempts for chunk processing */
@@ -40,6 +40,14 @@ export interface ChunkedProcessorOptions {
   retryDelayMs?: number;
   /** Custom license backend. If not set, uses ClearlyDefinedBackend when dashLicensesJar is absent. */
   backend?: LicenseBackend;
+  /**
+   * Pre-resolved cache from existing .deps/prod.md + .deps/dev.md.
+   * Keys are package identifiers (e.g. "express@4.18.0"); values are the
+   * resolved CQ string (e.g. "[clearlydefined](...)").
+   * Coordinates present in the cache are written directly to the output file
+   * without calling the API.  Omit or leave empty to query everything.
+   */
+  cachedResolutions?: Map<string, string>;
 }
 
 export class ChunkedDashLicensesProcessor {
@@ -64,7 +72,9 @@ export class ChunkedDashLicensesProcessor {
   }
 
   /**
-   * Process dependencies in chunks to avoid timeouts and API limits
+   * Process dependencies in chunks to avoid timeouts and API limits.
+   * If cachedResolutions is provided, coordinates that already appear in the
+   * cache are written directly to the output file without calling the API.
    */
   public async process(): Promise<void> {
     const startTime = Date.now();
@@ -81,12 +91,51 @@ export class ChunkedDashLicensesProcessor {
 
     logger.info(`Total dependencies to process: ${allDependencies.length}`);
 
+    // Step 1b: Apply cache — split into cached vs. new
+    const cache = this.options.cachedResolutions;
+    let depsToQuery = allDependencies;
+    const cachedLines: string[] = [];
+
+    if (cache && cache.size > 0) {
+      depsToQuery = [];
+      for (const coord of allDependencies) {
+        const id = coordinateToIdentifier(coord);
+        if (id && cache.has(id)) {
+          // Reconstruct a DEPENDENCIES-format line from the cached CQ value.
+          // Format: coordinate, license, approved, clearlydefined
+          const cq = cache.get(id)!;
+          // Extract license from cq map if we stored it; otherwise use 'unknown'
+          // (processAndGenerateDocuments will read licence from the DEPENDENCIES file)
+          // We emit a minimal valid line — licence will be re-read from ClearlyDefined
+          // data already embedded in the link.  Use 'approved' status.
+          const licenseMatch = cq.match(/\[([A-Za-z0-9\-. +]+)\]/);
+          const license = licenseMatch ? licenseMatch[1] : 'unknown';
+          cachedLines.push(`${coord}, ${license}, approved, clearlydefined`);
+        } else {
+          depsToQuery.push(coord);
+        }
+      }
+      if (cachedLines.length > 0) {
+        logger.info(`Cache hit: ${cachedLines.length} dependencies skipped (already resolved).`);
+      }
+      if (depsToQuery.length > 0) {
+        logger.info(`Cache miss: ${depsToQuery.length} new/unresolved dependencies to query.`);
+      }
+    }
+
+    // If all deps are cached, write the cached lines and we're done.
+    if (depsToQuery.length === 0) {
+      writeFileSync(this.options.outputFile, cachedLines.join('\n') + (cachedLines.length ? '\n' : ''));
+      logger.success(`Merged ${cachedLines.length} unique dependencies into ${this.options.outputFile}`);
+      logger.success(`Successfully processed all ${allDependencies.length} dependencies (all from cache)`);
+      logger.duration('Total processing time', Date.now() - startTime);
+      return;
+    }
+
     // Step 2: Split into chunks
     // Use batch size directly to ensure ClearlyDefined queries stay small
-    // (Eclipse Foundation resolves ~30-50%, leaving remaining for ClearlyDefined)
-    // With chunk = batch, ClearlyDefined gets ~70-150 items max, which is reliable
     const chunkSize = this.options.batchSize;
-    const chunks = this.splitIntoChunks(allDependencies, chunkSize);
+    const chunks = this.splitIntoChunks(depsToQuery, chunkSize);
 
     logger.info(`Split into ${chunks.length} chunks (max ${chunkSize} dependencies per chunk)`);
 
@@ -119,8 +168,9 @@ export class ChunkedDashLicensesProcessor {
     }
 
     // Step 4: Merge all chunk results into final DEPENDENCIES file
+    // Include cached lines so the full set of dependencies is in the output.
     logger.info('Merging chunk results...');
-    const totalEntries = this.mergeChunkResults(tempFiles);
+    const totalEntries = this.mergeChunkResults(tempFiles, cachedLines);
     logger.success(`Merged ${totalEntries} unique dependencies into ${this.options.outputFile}`);
 
     // Step 5: Clean up temporary files
@@ -275,20 +325,18 @@ export class ChunkedDashLicensesProcessor {
   }
 
   /**
-   * Merge all chunk results into final DEPENDENCIES file
+   * Merge all chunk results (and any pre-cached lines) into the final
+   * DEPENDENCIES file, deduplicating and sorting entries.
    */
-  private mergeChunkResults(tempFiles: string[]): number {
-    // Use a Set to deduplicate entries
-    const allEntries = new Set<string>();
+  private mergeChunkResults(tempFiles: string[], cachedLines: string[] = []): number {
+    const allEntries = new Set<string>(cachedLines);
 
     for (const tempFile of tempFiles) {
       if (existsSync(tempFile)) {
         try {
           const content = readFileSync(tempFile, 'utf8');
           const lines = parseNonEmptyLines(content);
-
           lines.forEach(line => allEntries.add(line));
-
           logger.debug(`  Merged ${lines.length} entries from ${tempFile}`);
         } catch (error: unknown) {
           const errorMsg = error instanceof Error ? error.message : String(error);
@@ -301,12 +349,8 @@ export class ChunkedDashLicensesProcessor {
       throw new Error('No entries found in any chunk output files');
     }
 
-    // Sort entries for consistent output (important for git diffs)
     const sortedEntries = Array.from(allEntries).sort();
-
-    // Write to final file
     writeFileSync(this.options.outputFile, sortedEntries.join('\n') + '\n', 'utf8');
-
     return sortedEntries.length;
   }
 

--- a/src/helpers/chunked-processor.ts
+++ b/src/helpers/chunked-processor.ts
@@ -56,6 +56,16 @@ export interface ChunkedProcessorOptions {
    * without calling the API.  Omit or leave empty to query everything.
    */
   cachedResolutions?: Map<string, CacheEntry>;
+  /**
+   * Set of production dependency identifiers (e.g. "express@4.18.0").
+   * Used to classify cache misses as prod vs dev in log output.
+   */
+  prodIdentifiers?: Set<string>;
+  /**
+   * Set of development dependency identifiers.
+   * Used to classify cache misses as prod vs dev in log output.
+   */
+  devIdentifiers?: Set<string>;
 }
 
 export class ChunkedDashLicensesProcessor {
@@ -127,7 +137,37 @@ export class ChunkedDashLicensesProcessor {
         logger.info(`Cache hit: ${cachedLines.length} dependencies skipped (already resolved).`);
       }
       if (depsToQuery.length > 0) {
-        logger.info(`Cache miss: ${depsToQuery.length} new/unresolved dependencies to query.`);
+        // Build a detailed breakdown so the log is actionable.
+        const prodSet = this.options.prodIdentifiers;
+        const devSet = this.options.devIdentifiers;
+        const cacheNameSet = new Set(
+          [...(cache?.keys() ?? [])].map(id => id.substring(0, id.lastIndexOf('@')))
+        );
+
+        let prod = 0, dev = 0, both = 0, versionBump = 0, brandNew = 0;
+        for (const id of depsToQuery) {
+          const isProd = prodSet?.has(id) ?? false;
+          const isDev  = devSet?.has(id) ?? false;
+          if (isProd && isDev) both++;
+          else if (isProd) prod++;
+          else if (isDev) dev++;
+
+          const pkgName = id.substring(0, id.lastIndexOf('@'));
+          if (cacheNameSet.has(pkgName)) versionBump++;
+          else brandNew++;
+        }
+
+        const parts: string[] = [];
+        if (prodSet && devSet) {
+          if (prod > 0)  parts.push(`${prod} prod`);
+          if (dev > 0)   parts.push(`${dev} dev`);
+          if (both > 0)  parts.push(`${both} prod+dev`);
+        }
+        if (versionBump > 0) parts.push(`${versionBump} version bump${versionBump > 1 ? 's' : ''}`);
+        if (brandNew > 0)    parts.push(`${brandNew} new package${brandNew > 1 ? 's' : ''}`);
+
+        const detail = parts.length > 0 ? ` (${parts.join(', ')})` : '';
+        logger.info(`Cache miss: ${depsToQuery.length} dependencies to query${detail}.`);
       }
     }
 

--- a/src/helpers/chunked-processor.ts
+++ b/src/helpers/chunked-processor.ts
@@ -38,7 +38,7 @@ export interface ChunkedProcessorOptions {
   retryDelayMs?: number;
   /**
    * Timeout for ClearlyDefined batch POST /definitions requests (ms).
-   * Default: 10 000 ms.
+   * Default: 30 000 ms.
    */
   postTimeoutMs?: number;
   /**

--- a/src/helpers/chunked-processor.ts
+++ b/src/helpers/chunked-processor.ts
@@ -161,14 +161,16 @@ export class ChunkedDashLicensesProcessor {
         );
 
         let prod = 0, dev = 0, both = 0, versionBump = 0, brandNew = 0;
-        for (const id of depsToQuery) {
+        for (const coord of depsToQuery) {
+          const id = coordinateToIdentifier(coord) || coord;
           const isProd = prodSet?.has(id) ?? false;
           const isDev  = devSet?.has(id) ?? false;
           if (isProd && isDev) both++;
           else if (isProd) prod++;
           else if (isDev) dev++;
 
-          const pkgName = id.substring(0, id.lastIndexOf('@'));
+          const atIdx = id.lastIndexOf('@');
+          const pkgName = atIdx > 0 ? id.substring(0, atIdx) : id;
           if (cacheNameSet.has(pkgName)) versionBump++;
           else brandNew++;
         }
@@ -217,8 +219,9 @@ export class ChunkedDashLicensesProcessor {
 
     // If all deps are cached, write the cached lines and we're done.
     if (depsToQuery.length === 0) {
-      writeFileSync(this.options.outputFile, cachedLines.join('\n') + (cachedLines.length ? '\n' : ''));
-      logger.success(`Merged ${cachedLines.length} unique dependencies into ${this.options.outputFile}`);
+      const sortedCached = Array.from(new Set(cachedLines)).sort();
+      writeFileSync(this.options.outputFile, sortedCached.join('\n') + (sortedCached.length ? '\n' : ''), 'utf8');
+      logger.success(`Merged ${sortedCached.length} unique dependencies into ${this.options.outputFile}`);
       logger.success(`Successfully processed all ${allDependencies.length} dependencies (all from cache)`);
       logger.duration('Total processing time', Date.now() - startTime);
       return;

--- a/src/helpers/chunked-processor.ts
+++ b/src/helpers/chunked-processor.ts
@@ -38,6 +38,16 @@ export interface ChunkedProcessorOptions {
   enableHarvest?: boolean;
   maxRetries?: number;
   retryDelayMs?: number;
+  /**
+   * Timeout for ClearlyDefined batch POST /definitions requests (ms).
+   * Default: 10 000 ms.
+   */
+  postTimeoutMs?: number;
+  /**
+   * Timeout for ClearlyDefined individual GET /definitions/{id} requests (ms).
+   * Default: 5 000 ms.
+   */
+  getTimeoutMs?: number;
   /** Custom license backend. If not set, uses ClearlyDefinedBackend when dashLicensesJar is absent. */
   backend?: LicenseBackend;
   /**
@@ -68,7 +78,11 @@ export class ChunkedDashLicensesProcessor {
             options.batchSize,
             options.debug
           )
-        : new ClearlyDefinedBackend({ enableHarvest: options.enableHarvest ?? false }));
+        : new ClearlyDefinedBackend({
+            enableHarvest: options.enableHarvest ?? false,
+            ...(options.postTimeoutMs !== undefined ? { postTimeoutMs: options.postTimeoutMs } : {}),
+            ...(options.getTimeoutMs !== undefined ? { getTimeoutMs: options.getTimeoutMs } : {}),
+          }));
   }
 
   /**

--- a/src/helpers/package-manager-base.ts
+++ b/src/helpers/package-manager-base.ts
@@ -15,6 +15,7 @@ import { existsSync, statSync, unlinkSync, copyFileSync, mkdirSync } from 'fs';
 import * as path from 'path';
 import { Environment, Options, PackageManagerResult, parseEnvironment, parseOptions } from './types';
 import { FILE_NAMES, getErrorMessage } from './utils';
+import { recheckAndCleanExcluded } from './recheck-excluded';
 
 /**
  * Configuration options for a package manager
@@ -300,6 +301,20 @@ export abstract class PackageManagerBase {
    */
   protected async checkRestrictions(): Promise<PackageManagerResult> {
     const restricted = await this.runBumpDeps();
+
+    // With --harvest, re-query every EXCLUDED entry against ClearlyDefined.
+    // Any entry now approved is removed from EXCLUDED automatically.
+    // Skip in --check mode — EXCLUDED files must not be modified during a check.
+    if (this.options.harvest && !this.options.check) {
+      const recheckOpts: { getTimeoutMs?: number; postTimeoutMs?: number } = {};
+      if (this.options.getTimeoutMs !== undefined) recheckOpts.getTimeoutMs = this.options.getTimeoutMs;
+      if (this.options.postTimeoutMs !== undefined) recheckOpts.postTimeoutMs = this.options.postTimeoutMs;
+      await recheckAndCleanExcluded(
+        path.join(this.env.DEPS_DIR, 'EXCLUDED', FILE_NAMES.PROD_MD),
+        path.join(this.env.DEPS_DIR, 'EXCLUDED', FILE_NAMES.DEV_MD),
+        recheckOpts
+      );
+    }
 
     let differProd = '';
     let differDev = '';

--- a/src/helpers/recheck-excluded.ts
+++ b/src/helpers/recheck-excluded.ts
@@ -48,7 +48,8 @@ export async function recheckAndCleanExcluded(
 
     const content = readFileSync(filePath, 'utf8');
     const toVerify: Array<{ id: string; coord: string }> = [];
-    const tablePattern = /^\| `([^`]+)` \| ([^|]+) \|$/gm;
+    // Matches both plain (| `pkg@v` | cq |) and linked-name (| [`pkg@v`](url) | cq |) rows.
+    const tablePattern = /^\| \[?`([^`]+)`(?:\]\([^)]*\))? \| ([^|]+) \|$/gm;
     let m: RegExpExecArray | null;
     while ((m = tablePattern.exec(content)) !== null) {
       const id = m[1].trim();

--- a/src/helpers/recheck-excluded.ts
+++ b/src/helpers/recheck-excluded.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2018-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { ClearlyDefinedBackend } from '../backends/clearlydefined-backend';
+import {
+  PackageManagerUtils,
+  coordinateToIdentifier,
+  identifierToCoordinate,
+  getErrorMessage,
+} from './utils';
+import { logger } from './logger';
+
+/**
+ * Re-query every entry in the EXCLUDED prod/dev markdown files against
+ * ClearlyDefined.  Any entry that comes back as approved is removed from the
+ * EXCLUDED file — it belongs in prod.md / dev.md instead.
+ *
+ * Entries with an `ecd.che` CQ are skipped: they are approved by the Eclipse
+ * Foundation, not by ClearlyDefined, and must remain in EXCLUDED.
+ *
+ * Called with --harvest to keep EXCLUDED files lean over time.
+ */
+export async function recheckAndCleanExcluded(
+  excludedProdPath: string,
+  excludedDevPath: string,
+  options?: { getTimeoutMs?: number; postTimeoutMs?: number }
+): Promise<void> {
+  const backend = new ClearlyDefinedBackend({
+    ...(options?.getTimeoutMs !== undefined ? { getTimeoutMs: options.getTimeoutMs } : {}),
+    ...(options?.postTimeoutMs !== undefined ? { postTimeoutMs: options.postTimeoutMs } : {}),
+  });
+
+  for (const [filePath, label] of [
+    [excludedProdPath, 'prod'],
+    [excludedDevPath, 'dev'],
+  ] as const) {
+    if (!existsSync(filePath)) continue;
+
+    const content = readFileSync(filePath, 'utf8');
+    const toVerify: Array<{ id: string; coord: string }> = [];
+    const tablePattern = /^\| `([^`]+)` \| ([^|]+) \|$/gm;
+    let m: RegExpExecArray | null;
+    while ((m = tablePattern.exec(content)) !== null) {
+      const id = m[1].trim();
+      const cq = m[2].trim();
+      // ecd.che = Eclipse Foundation approval — not managed by ClearlyDefined.
+      if (cq === 'ecd.che') continue;
+      const coord = identifierToCoordinate(id);
+      if (coord) toVerify.push({ id, coord });
+    }
+
+    if (toVerify.length === 0) continue;
+
+    logger.info(
+      `Rechecking ${toVerify.length} EXCLUDED/${label}.md entr${toVerify.length !== 1 ? 'ies' : 'y'} via ClearlyDefined...`
+    );
+
+    try {
+      const verifiedLines = await backend.processBatch(toVerify.map(e => e.coord));
+      const approvedIds = new Set<string>();
+      for (const line of verifiedLines) {
+        if (line.includes(', approved,')) {
+          const coord = line.split(',')[0].trim();
+          const id = coordinateToIdentifier(coord);
+          if (id) approvedIds.add(id);
+        }
+      }
+
+      if (approvedIds.size > 0) {
+        PackageManagerUtils.removeUnusedExcludes(filePath, approvedIds, 'utf8');
+        logger.info(
+          `Removed ${approvedIds.size} approved entr${approvedIds.size !== 1 ? 'ies' : 'y'} from EXCLUDED/${label}.md.`
+        );
+      } else {
+        logger.debug(`EXCLUDED/${label}.md: all remaining entries still require manual exclusion.`);
+      }
+    } catch (err) {
+      logger.warn(`Could not recheck EXCLUDED/${label}.md: ${getErrorMessage(err)}`);
+    }
+  }
+}

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -15,7 +15,6 @@
  */
 export interface LicenseInfo {
   License: string;
-  URL?: string;
 }
 
 /**

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -56,7 +56,7 @@ export interface Options {
   recheck: boolean;
   /**
    * Timeout for ClearlyDefined batch POST /definitions requests in ms.
-   * Default: 10 000 ms.
+   * Default: 30 000 ms.
    */
   postTimeoutMs?: number;
   /**

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -48,6 +48,12 @@ export interface Options {
   check: boolean;
   debug: boolean;
   harvest: boolean;
+  /**
+   * When true, bypass the .deps/prod.md + .deps/dev.md cache and re-query
+   * ClearlyDefined for every dependency, even ones already resolved.
+   * Default: false (cache is used).
+   */
+  recheck: boolean;
 }
 
 /**
@@ -84,10 +90,11 @@ export function parseEnvironment(overrides?: Partial<Environment>): Environment 
  * Pass overrides for library usage.
  */
 export function parseOptions(overrides?: Partial<Options>): Options {
-  const opts = {
+  const opts: Options = {
     check: process.argv.includes('--check'),
     debug: process.argv.includes('--debug'),
     harvest: process.argv.includes('--harvest'),
+    recheck: process.argv.includes('--recheck'),
   };
   return overrides ? { ...opts, ...overrides } : opts;
 }

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -54,6 +54,16 @@ export interface Options {
    * Default: false (cache is used).
    */
   recheck: boolean;
+  /**
+   * Timeout for ClearlyDefined batch POST /definitions requests in ms.
+   * Default: 10 000 ms.
+   */
+  postTimeoutMs?: number;
+  /**
+   * Timeout for ClearlyDefined individual GET /definitions/{id} requests in ms.
+   * Default: 5 000 ms.
+   */
+  getTimeoutMs?: number;
 }
 
 /**

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -100,12 +100,24 @@ export function parseEnvironment(overrides?: Partial<Environment>): Environment 
  * Pass overrides for library usage.
  */
 export function parseOptions(overrides?: Partial<Options>): Options {
-  const opts: Options = {
-    check: process.argv.includes('--check'),
-    debug: process.argv.includes('--debug'),
-    harvest: process.argv.includes('--harvest'),
-    recheck: process.argv.includes('--recheck'),
+  const args = process.argv.slice(2);
+  const readPositiveIntArg = (flag: string): number | undefined => {
+    const idx = args.indexOf(flag);
+    if (idx === -1 || !args[idx + 1]) return undefined;
+    const n = parseInt(args[idx + 1], 10);
+    return Number.isFinite(n) && n > 0 ? n : undefined;
   };
+
+  const opts: Options = {
+    check: args.includes('--check'),
+    debug: args.includes('--debug'),
+    harvest: args.includes('--harvest'),
+    recheck: args.includes('--recheck'),
+  };
+  const postTimeout = readPositiveIntArg('--post-timeout');
+  const getTimeout = readPositiveIntArg('--get-timeout');
+  if (postTimeout !== undefined) opts.postTimeoutMs = postTimeout;
+  if (getTimeout !== undefined) opts.getTimeoutMs = getTimeout;
   return overrides ? { ...opts, ...overrides } : opts;
 }
 

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -103,22 +103,48 @@ export interface ProcessingOptions {
 }
 
 /**
- * Parse an npm coordinate string into a package identifier.
+ * Parse a dependency coordinate or resolution string into a plain
+ * package identifier suitable for cache lookup.
  *
- * Coordinates use the ClearlyDefined format:
- *   npm/npmjs/-/express/4.18.0        → express@4.18.0
- *   npm/npmjs/@babel/core/7.0.0       → @babel/core@7.0.0
+ * Handles two input formats:
  *
- * Returns an empty string for non-npm coordinates or malformed input.
+ * 1. Yarn Berry resolution strings (from parseYarnLockfile):
+ *      express@npm:4.18.0              → express@4.18.0
+ *      @babel/core@npm:7.0.0          → @babel/core@7.0.0
+ *
+ * 2. ClearlyDefined coordinate strings (from npm/yarn1 parsers):
+ *      npm/npmjs/-/express/4.18.0     → express@4.18.0
+ *      npm/npmjs/@babel/core/7.0.0    → @babel/core@7.0.0
+ *
+ * Returns an empty string for unrecognised / malformed input.
  */
 export function coordinateToIdentifier(coordinate: string): string {
+  // Already a plain identifier: package@version
+  // e.g. express@4.18.0 or @babel/core@7.0.0 — used by yarn3 and npm processors
+  if (!coordinate.startsWith('npm/') && !coordinate.includes('@npm:')) {
+    const lastAt = coordinate.lastIndexOf('@');
+    if (lastAt > 0) return coordinate;
+  }
+
+  // Yarn Berry resolution: name@npm:version  (last @npm: wins for scoped pkgs)
+  const npmAt = coordinate.lastIndexOf('@npm:');
+  if (npmAt > 0) {
+    const name = coordinate.slice(0, npmAt);
+    const version = coordinate.slice(npmAt + 5); // skip '@npm:'
+    if (name && version) return `${name}@${version}`;
+  }
+
+  // ClearlyDefined coordinate: npm/npmjs/{scope}/{name}/{version}
   const parts = coordinate.split('/');
-  if (parts.length < 5 || parts[0] !== 'npm') return '';
-  const scope = parts[2];
-  const name = parts[3];
-  const version = parts.slice(4).join('/');
-  if (scope === '-') return `${name}@${version}`;
-  return `${scope}/${name}@${version}`;
+  if (parts.length >= 5 && parts[0] === 'npm') {
+    const scope = parts[2];
+    const name = parts[3];
+    const version = parts.slice(4).join('/');
+    if (scope === '-') return `${name}@${version}`;
+    return `${scope}/${name}@${version}`;
+  }
+
+  return '';
 }
 
 /**

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -100,6 +100,13 @@ export function getErrorMessage(error: unknown): string {
 export interface ProcessingOptions {
   harvest?: boolean;
   check?: boolean;
+  /**
+   * When provided and harvest is true, called with the list of **direct**
+   * unresolved dependency identifiers (the ones that end up in problems.md).
+   * Transitive unresolved deps (auto-added to EXCLUDED) are excluded.
+   * The function should be fire-and-forget; the caller does not await it.
+   */
+  harvestFn?: (identifiers: string[]) => Promise<void>;
 }
 
 /**
@@ -565,6 +572,21 @@ export class PackageManagerUtils {
         }
         // Suppress transitive deps from UNRESOLVED section and problems.md
         allTransitive.forEach(d => depsToCQ.set(d, 'transitive dependency'));
+      }
+
+      // Trigger harvest for DIRECT unresolved deps only (those that will
+      // appear in problems.md). Transitive deps are excluded — they are
+      // handled by EXCLUDED files and do not need ClearlyDefined to harvest.
+      if (isHarvest && options?.harvestFn) {
+        const directUnresolved = [
+          ...stillUnresolvedProd.filter(d => isDirectPackage(d)),
+          ...stillUnresolvedDev.filter(d => isDirectPackage(d)),
+        ];
+        if (directUnresolved.length > 0) {
+          // Fire-and-forget: harvestFn is async but we don't await it so
+          // the tool output is not blocked on harvest HTTP round-trips.
+          void options.harvestFn(directUnresolved);
+        }
       }
 
       // Generate production dependencies document

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -343,10 +343,18 @@ export class PackageManagerUtils {
     const lines = content.split(/\r?\n/);
     // Match both plain (`pkg@v`) and linked-name ([`pkg@v`](url)) rows.
     const tablePattern = /^\| \[?`([^`]+)`(?:\]\([^)]*\))? \| ([^|]+) \|$/;
+    // Normalize both sides so Yarn Berry / ClearlyDefined coordinates in
+    // identifiersToRemove or in the EXCLUDED file match each other.
+    const normalizedToRemove = new Set(
+      [...identifiersToRemove].map(id => coordinateToIdentifier(id.trim()) || id.trim()),
+    );
     const kept: string[] = [];
     for (const line of lines) {
       const m = line.match(tablePattern);
-      if (m && identifiersToRemove.has(m[1])) continue;
+      if (m) {
+        const rowId = coordinateToIdentifier(m[1].trim()) || m[1].trim();
+        if (normalizedToRemove.has(rowId)) continue;
+      }
       kept.push(line);
     }
     writeFileSync(excludedPath, kept.join('\n').trimEnd() + '\n', { encoding: encoding as BufferEncoding });

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -201,10 +201,11 @@ export function loadResolvedCache(
   for (const filePath of [prodMdPath, devMdPath]) {
     if (!existsSync(filePath)) continue;
     const content = readFileSync(filePath, { encoding: 'utf8' as BufferEncoding });
-    // Match both plain-backtick and linked-name table row formats:
-    //   | `pkg@version` | license | cq |
-    //   | [`pkg@version`](url) | license | cq |
-    const rowPattern = /^\| \[?`([^`]+)`(?:\]\([^)]*\))? \| ([^|]+) \| (.+) \|$/gm;
+    // Match table row formats (plain backtick or linked name; license may be empty):
+    //   | `pkg@version` | MIT | [clearlydefined](...) |
+    //   | [`pkg@version`](url) | MIT | [clearlydefined](...) |
+    //   | `pkg@version` |  | ecd.che |   ← empty license (EXCLUDED-sourced entries)
+    const rowPattern = /^\| \[?`([^`]+)`(?:\]\([^)]*\))? \| ([^|]*) \| (.+) \|$/gm;
     let match: RegExpExecArray | null;
     while ((match = rowPattern.exec(content)) !== null) {
       const identifier = match[1].trim();

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -170,9 +170,18 @@ export function identifierToCoordinate(identifier: string): string {
   return `npm/npmjs/-/${name}/${version}`;
 }
 
+/** Entry stored in the resolved dependency cache. */
+export interface CacheEntry {
+  /** SPDX license string from the .deps/*.md table row (e.g. "MIT"). */
+  license: string;
+  /** Resolved CQ value (e.g. "[clearlydefined](https://...)"). */
+  cq: string;
+}
+
 /**
  * Load already-resolved dependencies from the existing .deps/prod.md and
- * .deps/dev.md files and return them as a map of identifier → cq_value.
+ * .deps/dev.md files and return them as a map of
+ * identifier → { license, cq }.
  *
  * Only entries whose "Resolved CQs" column is non-empty are included.
  * Empty CQ cells mean the dependency is still unresolved and must be queried.
@@ -180,18 +189,24 @@ export function identifierToCoordinate(identifier: string): string {
 export function loadResolvedCache(
   prodMdPath: string,
   devMdPath: string,
-): Map<string, string> {
-  const cache = new Map<string, string>();
+): Map<string, CacheEntry> {
+  const cache = new Map<string, CacheEntry>();
   for (const filePath of [prodMdPath, devMdPath]) {
     if (!existsSync(filePath)) continue;
     const content = readFileSync(filePath, { encoding: 'utf8' as BufferEncoding });
-    const rowPattern = /^\| `([^`]+)` \| ([^|]+) \| (.+) \|$/gm;
+    // Match both plain-backtick and linked-name table row formats:
+    //   | `pkg@version` | license | cq |
+    //   | [`pkg@version`](url) | license | cq |
+    const rowPattern = /^\| \[?`([^`]+)`(?:\]\([^)]*\))? \| ([^|]+) \| (.+) \|$/gm;
     let match: RegExpExecArray | null;
     while ((match = rowPattern.exec(content)) !== null) {
       const identifier = match[1].trim();
+      const license = match[2].trim();
       const cq = match[3].trim();
-      if (cq) {
-        cache.set(identifier, cq);
+      // Only cache entries with an actual resolution — skip placeholders like
+      // "transitive dependency" that don't represent a real ClearlyDefined result.
+      if (cq && cq !== 'transitive dependency') {
+        cache.set(identifier, { license, cq });
       }
     }
   }

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -198,6 +198,8 @@ export function loadResolvedCache(
   devMdPath: string,
 ): Map<string, CacheEntry> {
   const cache = new Map<string, CacheEntry>();
+
+  // ── prod.md / dev.md (3-column: identifier | license | cq) ─────────────
   for (const filePath of [prodMdPath, devMdPath]) {
     if (!existsSync(filePath)) continue;
     const content = readFileSync(filePath, { encoding: 'utf8' as BufferEncoding });
@@ -218,6 +220,28 @@ export function loadResolvedCache(
       }
     }
   }
+
+  // ── EXCLUDED files (2-column: identifier | cq) ──────────────────────────
+  // Deps in EXCLUDED are already classified (transitive or manually excluded).
+  // Cache them so subsequent runs skip the ClearlyDefined API call entirely.
+  const dir = path.dirname(prodMdPath);
+  const excludedProd = path.join(dir, 'EXCLUDED', 'prod.md');
+  const excludedDev  = path.join(dir, 'EXCLUDED', 'dev.md');
+  for (const filePath of [excludedProd, excludedDev]) {
+    if (!existsSync(filePath)) continue;
+    const content = readFileSync(filePath, { encoding: 'utf8' as BufferEncoding });
+    // EXCLUDED format: | `identifier` | cq_value |   (no license column)
+    const excludedPattern = /^\| `([^`]+)` \| ([^|]+) \|$/gm;
+    let match: RegExpExecArray | null;
+    while ((match = excludedPattern.exec(content)) !== null) {
+      const identifier = match[1].trim();
+      const cq = match[2].trim();
+      if (identifier && cq) {
+        cache.set(identifier, { license: '', cq });
+      }
+    }
+  }
+
   return cache;
 }
 
@@ -559,13 +583,19 @@ export class PackageManagerUtils {
 
       const allTransitive = [...transitiveProd, ...transitiveDev];
       if (allTransitive.length > 0) {
-        if (isHarvest) {
+        if (!isCheck) {
+          // Always write transitive deps to EXCLUDED in generate mode so that
+          // subsequent runs can skip the ClearlyDefined API call for them.
+          // Without this, every run re-queries the same transitive deps.
           this.appendTransitiveExcludes(paths.EXCLUDED_PROD_MD, transitiveProd, paths.ENCODING);
           this.appendTransitiveExcludes(paths.EXCLUDED_DEV_MD, transitiveDev, paths.ENCODING);
-        } else {
-          const suggestion = isCheck
-            ? 'Run with --harvest to automatically add them, or update .deps/EXCLUDED manually.'
-            : 'Run with --harvest to automatically add them to .deps/EXCLUDED.';
+        }
+        if (!isHarvest && !isCheck) {
+          console.log(`\nNote: ${allTransitive.length} UNRESOLVED transitive dep(s) added to .deps/EXCLUDED.`);
+          console.log('  Run with --recheck to re-query them from scratch.');
+          console.log();
+        } else if (isCheck) {
+          const suggestion = 'Run without --check to persist them to .deps/EXCLUDED.';
           console.log(`\nNote: ${allTransitive.length} UNRESOLVED transitive dep(s) found. ${suggestion}`);
           console.log('  .deps/EXCLUDED should be updated with the next transitive deps:');
           allTransitive.forEach(d => console.log(`    - ${d}`));

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -100,6 +100,8 @@ export function getErrorMessage(error: unknown): string {
 export interface ProcessingOptions {
   harvest?: boolean;
   check?: boolean;
+  /** GET timeout (ms) forwarded to triggerHarvestAsync. Defaults to 5 000. */
+  getTimeoutMs?: number;
   /**
    * When provided and harvest is true, called with the list of **direct**
    * unresolved dependency identifiers (the ones that end up in problems.md).
@@ -170,6 +172,7 @@ export function identifierToCoordinate(identifier: string): string {
   if (!version) return '';
   if (name.startsWith('@')) {
     const slashIdx = name.indexOf('/');
+    if (slashIdx <= 1 || slashIdx === name.length - 1) return '';
     const scope = name.slice(0, slashIdx);
     const pkg = name.slice(slashIdx + 1);
     return `npm/npmjs/${scope}/${pkg}/${version}`;
@@ -616,7 +619,9 @@ export class PackageManagerUtils {
         if (directUnresolved.length > 0) {
           // Fire-and-forget: harvestFn is async but we don't await it so
           // the tool output is not blocked on harvest HTTP round-trips.
-          void options.harvestFn(directUnresolved);
+          void options.harvestFn([...new Set(directUnresolved)]).catch((err: unknown) => {
+            logger.warn(`Harvest trigger failed: ${getErrorMessage(err)}`);
+          });
         }
       }
 

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -213,7 +213,9 @@ export function loadResolvedCache(
     const rowPattern = /^\| \[?`([^`]+)`(?:\]\([^)]*\))? \| ([^|]*) \| (.+) \|$/gm;
     let match: RegExpExecArray | null;
     while ((match = rowPattern.exec(content)) !== null) {
-      const identifier = match[1].trim();
+      // Normalize to plain name@version so Yarn Berry (@npm:) and ClearlyDefined
+      // coordinates (npm/npmjs/…) hit the same cache key as processor lookups.
+      const identifier = coordinateToIdentifier(match[1].trim()) || match[1].trim();
       const license = match[2].trim();
       const cq = match[3].trim();
       // Only cache entries with an actual resolution — skip placeholders like
@@ -234,10 +236,10 @@ export function loadResolvedCache(
     if (!existsSync(filePath)) continue;
     const content = readFileSync(filePath, { encoding: 'utf8' as BufferEncoding });
     // EXCLUDED format: | `identifier` | cq_value |   (no license column)
-    const excludedPattern = /^\| `([^`]+)` \| ([^|]+) \|$/gm;
+    const excludedPattern = /^\| \[?`([^`]+)`(?:\]\([^)]*\))? \| ([^|]+) \|$/gm;
     let match: RegExpExecArray | null;
     while ((match = excludedPattern.exec(content)) !== null) {
-      const identifier = match[1].trim();
+      const identifier = coordinateToIdentifier(match[1].trim()) || match[1].trim();
       const cq = match[2].trim();
       if (identifier && cq) {
         cache.set(identifier, { license: '', cq });
@@ -339,7 +341,8 @@ export class PackageManagerUtils {
     if (!existsSync(excludedPath) || identifiersToRemove.size === 0) return;
     const content = readFileSync(excludedPath, { encoding: encoding as BufferEncoding });
     const lines = content.split(/\r?\n/);
-    const tablePattern = /^\| `([^|^ ]+)` \| ([^|]+) \|$/;
+    // Match both plain (`pkg@v`) and linked-name ([`pkg@v`](url)) rows.
+    const tablePattern = /^\| \[?`([^`]+)`(?:\]\([^)]*\))? \| ([^|]+) \|$/;
     const kept: string[] = [];
     for (const line of lines) {
       const m = line.match(tablePattern);
@@ -577,6 +580,30 @@ export class PackageManagerUtils {
         const name = getPackageName(id);
         return directDeps.prod.has(name) || directDeps.dev.has(name);
       };
+
+      // A package that was previously cached as "transitive dependency" but is
+      // now a direct dependency must be re-evaluated: remove its stale EXCLUDED
+      // entry so it goes through ClearlyDefined lookup again.
+      const staleTransitiveProd = prodDeps.filter(
+        d => depsToCQ.get(d) === 'transitive dependency' && isDirectPackage(d),
+      );
+      const staleTransitiveDev = devDeps.filter(
+        d => depsToCQ.get(d) === 'transitive dependency' && isDirectPackage(d),
+      );
+      if (staleTransitiveProd.length > 0 || staleTransitiveDev.length > 0) {
+        staleTransitiveProd.forEach(d => depsToCQ.delete(d));
+        staleTransitiveDev.forEach(d => depsToCQ.delete(d));
+        PackageManagerUtils.removeUnusedExcludes(
+          paths.EXCLUDED_PROD_MD,
+          new Set(staleTransitiveProd),
+          paths.ENCODING,
+        );
+        PackageManagerUtils.removeUnusedExcludes(
+          paths.EXCLUDED_DEV_MD,
+          new Set(staleTransitiveDev),
+          paths.ENCODING,
+        );
+      }
 
       const stillUnresolvedProd = prodDeps.filter(d => !depsToCQ.has(d));
       const transitiveProd = stillUnresolvedProd.filter(d => !isDirectPackage(d));

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -103,6 +103,76 @@ export interface ProcessingOptions {
 }
 
 /**
+ * Parse an npm coordinate string into a package identifier.
+ *
+ * Coordinates use the ClearlyDefined format:
+ *   npm/npmjs/-/express/4.18.0        → express@4.18.0
+ *   npm/npmjs/@babel/core/7.0.0       → @babel/core@7.0.0
+ *
+ * Returns an empty string for non-npm coordinates or malformed input.
+ */
+export function coordinateToIdentifier(coordinate: string): string {
+  const parts = coordinate.split('/');
+  if (parts.length < 5 || parts[0] !== 'npm') return '';
+  const scope = parts[2];
+  const name = parts[3];
+  const version = parts.slice(4).join('/');
+  if (scope === '-') return `${name}@${version}`;
+  return `${scope}/${name}@${version}`;
+}
+
+/**
+ * Convert a package identifier back to an npm coordinate.
+ *
+ *   express@4.18.0      → npm/npmjs/-/express/4.18.0
+ *   @babel/core@7.0.0  → npm/npmjs/@babel/core/7.0.0
+ *
+ * Returns an empty string for identifiers without a version.
+ */
+export function identifierToCoordinate(identifier: string): string {
+  const atIdx = identifier.lastIndexOf('@');
+  if (atIdx <= 0) return '';
+  const name = identifier.slice(0, atIdx);
+  const version = identifier.slice(atIdx + 1);
+  if (!version) return '';
+  if (name.startsWith('@')) {
+    const slashIdx = name.indexOf('/');
+    const scope = name.slice(0, slashIdx);
+    const pkg = name.slice(slashIdx + 1);
+    return `npm/npmjs/${scope}/${pkg}/${version}`;
+  }
+  return `npm/npmjs/-/${name}/${version}`;
+}
+
+/**
+ * Load already-resolved dependencies from the existing .deps/prod.md and
+ * .deps/dev.md files and return them as a map of identifier → cq_value.
+ *
+ * Only entries whose "Resolved CQs" column is non-empty are included.
+ * Empty CQ cells mean the dependency is still unresolved and must be queried.
+ */
+export function loadResolvedCache(
+  prodMdPath: string,
+  devMdPath: string,
+): Map<string, string> {
+  const cache = new Map<string, string>();
+  for (const filePath of [prodMdPath, devMdPath]) {
+    if (!existsSync(filePath)) continue;
+    const content = readFileSync(filePath, { encoding: 'utf8' as BufferEncoding });
+    const rowPattern = /^\| `([^`]+)` \| ([^|]+) \| (.+) \|$/gm;
+    let match: RegExpExecArray | null;
+    while ((match = rowPattern.exec(content)) !== null) {
+      const identifier = match[1].trim();
+      const cq = match[3].trim();
+      if (cq) {
+        cache.set(identifier, cq);
+      }
+    }
+  }
+  return cache;
+}
+
+/**
  * Shared utilities for package manager implementations
  */
 export class PackageManagerUtils {

--- a/src/library.ts
+++ b/src/library.ts
@@ -37,6 +37,16 @@ export interface LibraryConfig {
    * ClearlyDefined for every dependency (default: false — cache is used).
    */
   recheck?: boolean;
+  /**
+   * Timeout for ClearlyDefined batch POST /definitions requests in ms.
+   * Default: 10 000 ms.
+   */
+  postTimeoutMs?: number;
+  /**
+   * Timeout for ClearlyDefined individual GET /definitions/{id} requests in ms.
+   * Default: 5 000 ms.
+   */
+  getTimeoutMs?: number;
   /** Optional path to Eclipse dash-licenses.jar for fallback check of unresolved dev deps */
   jarPath?: string;
 }
@@ -126,6 +136,8 @@ export async function generate(config: LibraryConfig): Promise<LibraryResult> {
     debug: config.debug ?? false,
     harvest: config.harvest ?? false,
     recheck: config.recheck ?? false,
+    ...(config.postTimeoutMs !== undefined ? { postTimeoutMs: config.postTimeoutMs } : {}),
+    ...(config.getTimeoutMs !== undefined ? { getTimeoutMs: config.getTimeoutMs } : {}),
   };
 
   // Ensure .deps directory structure exists

--- a/src/library.ts
+++ b/src/library.ts
@@ -32,6 +32,11 @@ export interface LibraryConfig {
   debug?: boolean;
   /** If true, request harvest for unresolved dependencies from ClearlyDefined (default: false) */
   harvest?: boolean;
+  /**
+   * If true, bypass the .deps/prod.md + .deps/dev.md cache and re-query
+   * ClearlyDefined for every dependency (default: false — cache is used).
+   */
+  recheck?: boolean;
   /** Optional path to Eclipse dash-licenses.jar for fallback check of unresolved dev deps */
   jarPath?: string;
 }
@@ -119,7 +124,8 @@ export async function generate(config: LibraryConfig): Promise<LibraryResult> {
   const options = {
     check: config.check ?? false,
     debug: config.debug ?? false,
-    harvest: config.harvest ?? false
+    harvest: config.harvest ?? false,
+    recheck: config.recheck ?? false,
   };
 
   // Ensure .deps directory structure exists

--- a/src/package-managers/npm/bump-deps.ts
+++ b/src/package-managers/npm/bump-deps.ts
@@ -99,16 +99,17 @@ export class NpmDependencyProcessor {
       });
 
       // Process and generate documents
-      const harvestFn = options?.harvest
-        ? (ids: string[]) => triggerHarvestAsync(ids, 5000)
-        : undefined;
+      const processOptions: ProcessingOptions = { ...options };
+      if (options?.harvest) {
+        processOptions.harvestFn = (ids: string[]) => triggerHarvestAsync(ids, 5000);
+      }
 
       PackageManagerUtils.processAndGenerateDocuments(
         prodDeps,
         devDeps,
         this.allDependencies,
         this.paths,
-        { ...options, harvestFn },
+        processOptions,
       );
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/src/package-managers/npm/bump-deps.ts
+++ b/src/package-managers/npm/bump-deps.ts
@@ -57,20 +57,9 @@ export class NpmDependencyProcessor {
         const pkgJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
         
         if (pkgJson.license) {
-          licenseInfo.License = typeof pkgJson.license === 'string' 
-            ? pkgJson.license 
+          licenseInfo.License = typeof pkgJson.license === 'string'
+            ? pkgJson.license
             : pkgJson.license.type || '';
-        }
-        
-        if (pkgJson.homepage) {
-          licenseInfo.URL = pkgJson.homepage;
-        } else if (pkgJson.repository) {
-          const repo = typeof pkgJson.repository === 'string' 
-            ? pkgJson.repository 
-            : pkgJson.repository.url || '';
-          if (repo) {
-            licenseInfo.URL = repo.replace(/^git\+/, '').replace(/\.git$/, '');
-          }
         }
       }
     } catch (error) {

--- a/src/package-managers/npm/bump-deps.ts
+++ b/src/package-managers/npm/bump-deps.ts
@@ -101,7 +101,7 @@ export class NpmDependencyProcessor {
       // Process and generate documents
       const processOptions: ProcessingOptions = { ...options };
       if (options?.harvest) {
-        processOptions.harvestFn = (ids: string[]) => triggerHarvestAsync(ids, 5000);
+        processOptions.harvestFn = (ids: string[]) => triggerHarvestAsync(ids, options.getTimeoutMs ?? 5000);
       }
 
       PackageManagerUtils.processAndGenerateDocuments(

--- a/src/package-managers/npm/bump-deps.ts
+++ b/src/package-managers/npm/bump-deps.ts
@@ -13,6 +13,7 @@
 import * as path from 'path';
 import { readFileSync, existsSync } from 'fs';
 import { PackageManagerUtils, type FilePaths, type ProcessingOptions } from '../../helpers/utils';
+import { triggerHarvestAsync } from '../../backends/harvest';
 import type { LicenseMap, LicenseInfo } from '../../document';
 
 /**
@@ -98,12 +99,16 @@ export class NpmDependencyProcessor {
       });
 
       // Process and generate documents
+      const harvestFn = options?.harvest
+        ? (ids: string[]) => triggerHarvestAsync(ids, 5000)
+        : undefined;
+
       PackageManagerUtils.processAndGenerateDocuments(
         prodDeps,
         devDeps,
         this.allDependencies,
         this.paths,
-        options
+        { ...options, harvestFn },
       );
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/src/package-managers/npm/npm-processor.ts
+++ b/src/package-managers/npm/npm-processor.ts
@@ -76,7 +76,6 @@ export class NpmProcessor extends PackageManagerBase {
         batchSize: parseInt(this.env.BATCH_SIZE),
         outputFile: depsFilePath,
         debug: this.options.debug,
-        enableHarvest: this.options.harvest,
         ...(this.options.postTimeoutMs !== undefined ? { postTimeoutMs: this.options.postTimeoutMs } : {}),
         ...(this.options.getTimeoutMs !== undefined ? { getTimeoutMs: this.options.getTimeoutMs } : {}),
         ...(cachedResolutions ? { cachedResolutions } : {}),

--- a/src/package-managers/npm/npm-processor.ts
+++ b/src/package-managers/npm/npm-processor.ts
@@ -77,6 +77,8 @@ export class NpmProcessor extends PackageManagerBase {
         outputFile: depsFilePath,
         debug: this.options.debug,
         enableHarvest: this.options.harvest,
+        ...(this.options.postTimeoutMs !== undefined ? { postTimeoutMs: this.options.postTimeoutMs } : {}),
+        ...(this.options.getTimeoutMs !== undefined ? { getTimeoutMs: this.options.getTimeoutMs } : {}),
         ...(cachedResolutions ? { cachedResolutions } : {}),
       });
 

--- a/src/package-managers/npm/npm-processor.ts
+++ b/src/package-managers/npm/npm-processor.ts
@@ -18,6 +18,7 @@ import { parseNpmDependencies } from './parser';
 import { NpmDependencyProcessor } from './bump-deps';
 import type { Environment, Options } from '../../helpers/types';
 import { environmentToProcessEnv } from '../../helpers/types';
+import { loadResolvedCache } from '../../helpers/utils';
 
 /**
  * NPM package manager processor.
@@ -61,6 +62,13 @@ export class NpmProcessor extends PackageManagerBase {
     const depsFilePath = path.join(this.env.TMP_DIR, 'DEPENDENCIES');
 
     try {
+      const cachedResolutions = this.options.recheck
+        ? undefined
+        : loadResolvedCache(
+            path.join(this.env.DEPS_DIR, 'prod.md'),
+            path.join(this.env.DEPS_DIR, 'dev.md'),
+          );
+
       const processor = new ChunkedDashLicensesProcessor({
         parserScript: 'cat',
         parserInput: allDepsFile,
@@ -68,7 +76,8 @@ export class NpmProcessor extends PackageManagerBase {
         batchSize: parseInt(this.env.BATCH_SIZE),
         outputFile: depsFilePath,
         debug: this.options.debug,
-        enableHarvest: this.options.harvest
+        enableHarvest: this.options.harvest,
+        ...(cachedResolutions ? { cachedResolutions } : {}),
       });
 
       await processor.process();

--- a/src/package-managers/npm/npm-processor.ts
+++ b/src/package-managers/npm/npm-processor.ts
@@ -76,6 +76,8 @@ export class NpmProcessor extends PackageManagerBase {
         batchSize: parseInt(this.env.BATCH_SIZE),
         outputFile: depsFilePath,
         debug: this.options.debug,
+        prodIdentifiers: new Set(allDeps.dependencies),
+        devIdentifiers: new Set(allDeps.devDependencies),
         ...(this.options.postTimeoutMs !== undefined ? { postTimeoutMs: this.options.postTimeoutMs } : {}),
         ...(this.options.getTimeoutMs !== undefined ? { getTimeoutMs: this.options.getTimeoutMs } : {}),
         ...(cachedResolutions ? { cachedResolutions } : {}),

--- a/src/package-managers/npm/npm-processor.ts
+++ b/src/package-managers/npm/npm-processor.ts
@@ -102,7 +102,9 @@ export class NpmProcessor extends PackageManagerBase {
     console.log('Checking dependencies for restrictions to use...');
     try {
       const processor = new NpmDependencyProcessor();
-      processor.process({ harvest: this.options.harvest, check: this.options.check });
+      const procOpts: import('../../helpers/utils').ProcessingOptions = { harvest: this.options.harvest, check: this.options.check };
+      if (this.options.getTimeoutMs !== undefined) procOpts.getTimeoutMs = this.options.getTimeoutMs;
+      processor.process(procOpts);
       return 0;
     } catch (error) {
       // Error already logged by the processor

--- a/src/package-managers/yarn/bump-deps.ts
+++ b/src/package-managers/yarn/bump-deps.ts
@@ -79,13 +79,9 @@ export class YarnDependencyProcessor {
       const { head, body } = licenses.data;
 
       body.forEach((libInfo: string[]) => {
-        const url = libInfo[head.indexOf('URL')];
         const licenseInfo: LicenseInfo = {
           License: libInfo[head.indexOf('License')]
         };
-        if (url !== 'Unknown') {
-          licenseInfo.URL = url;
-        }
         this.allDependencies.set(
           `${libInfo[head.indexOf('Name')]}@${libInfo[head.indexOf('Version')]}`,
           licenseInfo

--- a/src/package-managers/yarn/bump-deps.ts
+++ b/src/package-managers/yarn/bump-deps.ts
@@ -118,16 +118,17 @@ export class YarnDependencyProcessor {
       const devDeps = allDeps.filter(entry => !prodDeps.includes(entry));
 
       // Process and generate documents using shared utility
-      const harvestFn = options?.harvest
-        ? (ids: string[]) => triggerHarvestAsync(ids, 5000)
-        : undefined;
+      const processOptions: ProcessingOptions = { ...options };
+      if (options?.harvest) {
+        processOptions.harvestFn = (ids: string[]) => triggerHarvestAsync(ids, 5000);
+      }
 
       PackageManagerUtils.processAndGenerateDocuments(
         prodDeps,
         devDeps,
         this.allDependencies,
         this.paths,
-        { ...options, harvestFn },
+        processOptions,
       );
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/src/package-managers/yarn/bump-deps.ts
+++ b/src/package-managers/yarn/bump-deps.ts
@@ -120,7 +120,7 @@ export class YarnDependencyProcessor {
       // Process and generate documents using shared utility
       const processOptions: ProcessingOptions = { ...options };
       if (options?.harvest) {
-        processOptions.harvestFn = (ids: string[]) => triggerHarvestAsync(ids, 5000);
+        processOptions.harvestFn = (ids: string[]) => triggerHarvestAsync(ids, options.getTimeoutMs ?? 5000);
       }
 
       PackageManagerUtils.processAndGenerateDocuments(

--- a/src/package-managers/yarn/bump-deps.ts
+++ b/src/package-managers/yarn/bump-deps.ts
@@ -13,6 +13,7 @@
 import * as path from 'path';
 import { readFileSync } from 'fs';
 import { PackageManagerUtils, type FilePaths, type ProcessingOptions } from '../../helpers/utils';
+import { triggerHarvestAsync } from '../../backends/harvest';
 import type { LicenseMap, LicenseInfo } from '../../document';
 
 /**
@@ -117,12 +118,16 @@ export class YarnDependencyProcessor {
       const devDeps = allDeps.filter(entry => !prodDeps.includes(entry));
 
       // Process and generate documents using shared utility
+      const harvestFn = options?.harvest
+        ? (ids: string[]) => triggerHarvestAsync(ids, 5000)
+        : undefined;
+
       PackageManagerUtils.processAndGenerateDocuments(
         prodDeps,
         devDeps,
         this.allDependencies,
         this.paths,
-        options
+        { ...options, harvestFn },
       );
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/src/package-managers/yarn/yarn-processor.ts
+++ b/src/package-managers/yarn/yarn-processor.ts
@@ -19,6 +19,7 @@ import { parseYarnDependencies } from './parser';
 import { YarnDependencyProcessor } from './bump-deps';
 import type { Environment, Options } from '../../helpers/types';
 import { environmentToProcessEnv } from '../../helpers/types';
+import { loadResolvedCache } from '../../helpers/utils';
 
 /**
  * Yarn v1 package manager processor.
@@ -61,6 +62,13 @@ export class YarnProcessor extends PackageManagerBase {
     const depsFilePath = path.join(this.env.TMP_DIR, 'DEPENDENCIES');
 
     try {
+      const cachedResolutions = this.options.recheck
+        ? undefined
+        : loadResolvedCache(
+            path.join(this.env.DEPS_DIR, 'prod.md'),
+            path.join(this.env.DEPS_DIR, 'dev.md'),
+          );
+
       const processor = new ChunkedDashLicensesProcessor({
         parserScript: 'cat',
         parserInput: allDepsFile,
@@ -68,7 +76,8 @@ export class YarnProcessor extends PackageManagerBase {
         batchSize: parseInt(this.env.BATCH_SIZE),
         outputFile: depsFilePath,
         debug: this.options.debug,
-        enableHarvest: this.options.harvest
+        enableHarvest: this.options.harvest,
+        ...(cachedResolutions ? { cachedResolutions } : {}),
       });
 
       await processor.process();

--- a/src/package-managers/yarn/yarn-processor.ts
+++ b/src/package-managers/yarn/yarn-processor.ts
@@ -120,7 +120,9 @@ export class YarnProcessor extends PackageManagerBase {
     console.log('Checking dependencies for restrictions to use...');
     try {
       const processor = new YarnDependencyProcessor();
-      processor.process({ harvest: this.options.harvest, check: this.options.check });
+      const procOpts: import('../../helpers/utils').ProcessingOptions = { harvest: this.options.harvest, check: this.options.check };
+      if (this.options.getTimeoutMs !== undefined) procOpts.getTimeoutMs = this.options.getTimeoutMs;
+      processor.process(procOpts);
       return 0;
     } catch (error) {
       // Error already logged by the processor

--- a/src/package-managers/yarn/yarn-processor.ts
+++ b/src/package-managers/yarn/yarn-processor.ts
@@ -76,7 +76,6 @@ export class YarnProcessor extends PackageManagerBase {
         batchSize: parseInt(this.env.BATCH_SIZE),
         outputFile: depsFilePath,
         debug: this.options.debug,
-        enableHarvest: this.options.harvest,
         ...(this.options.postTimeoutMs !== undefined ? { postTimeoutMs: this.options.postTimeoutMs } : {}),
         ...(this.options.getTimeoutMs !== undefined ? { getTimeoutMs: this.options.getTimeoutMs } : {}),
         ...(cachedResolutions ? { cachedResolutions } : {}),

--- a/src/package-managers/yarn/yarn-processor.ts
+++ b/src/package-managers/yarn/yarn-processor.ts
@@ -77,6 +77,8 @@ export class YarnProcessor extends PackageManagerBase {
         outputFile: depsFilePath,
         debug: this.options.debug,
         enableHarvest: this.options.harvest,
+        ...(this.options.postTimeoutMs !== undefined ? { postTimeoutMs: this.options.postTimeoutMs } : {}),
+        ...(this.options.getTimeoutMs !== undefined ? { getTimeoutMs: this.options.getTimeoutMs } : {}),
         ...(cachedResolutions ? { cachedResolutions } : {}),
       });
 

--- a/src/package-managers/yarn3/bump-deps.ts
+++ b/src/package-managers/yarn3/bump-deps.ts
@@ -77,7 +77,7 @@ export class Yarn3DependencyProcessor {
 
       const processOptions: ProcessingOptions = { ...options };
       if (options?.harvest) {
-        processOptions.harvestFn = (ids: string[]) => triggerHarvestAsync(ids, 5000);
+        processOptions.harvestFn = (ids: string[]) => triggerHarvestAsync(ids, options.getTimeoutMs ?? 5000);
       }
 
       PackageManagerUtils.processAndGenerateDocuments(

--- a/src/package-managers/yarn3/bump-deps.ts
+++ b/src/package-managers/yarn3/bump-deps.ts
@@ -75,16 +75,17 @@ export class Yarn3DependencyProcessor {
         this.allDependencies.set(pkg, this.extractLicenseInfo(pkg));
       });
 
-      const harvestFn = options?.harvest
-        ? (ids: string[]) => triggerHarvestAsync(ids, 5000)
-        : undefined;
+      const processOptions: ProcessingOptions = { ...options };
+      if (options?.harvest) {
+        processOptions.harvestFn = (ids: string[]) => triggerHarvestAsync(ids, 5000);
+      }
 
       PackageManagerUtils.processAndGenerateDocuments(
         prodDeps,
         devDeps,
         this.allDependencies,
         this.paths,
-        { ...options, harvestFn },
+        processOptions,
       );
     } catch (error) {
       const msg = error instanceof Error ? error.message : 'Unknown error';

--- a/src/package-managers/yarn3/bump-deps.ts
+++ b/src/package-managers/yarn3/bump-deps.ts
@@ -47,11 +47,6 @@ export class Yarn3DependencyProcessor {
         if (pkg.license) {
           info.License = typeof pkg.license === 'string' ? pkg.license : pkg.license.type || '';
         }
-        if (pkg.homepage) info.URL = pkg.homepage;
-        else if (pkg.repository) {
-          const repo = typeof pkg.repository === 'string' ? pkg.repository : pkg.repository?.url || '';
-          if (repo) info.URL = repo.replace(/^git\+/, '').replace(/\.git$/, '');
-        }
       }
     } catch {
       // Ignore per-package errors

--- a/src/package-managers/yarn3/bump-deps.ts
+++ b/src/package-managers/yarn3/bump-deps.ts
@@ -13,6 +13,7 @@
 import * as path from 'path';
 import { readFileSync, existsSync } from 'fs';
 import { PackageManagerUtils, type FilePaths, type ProcessingOptions } from '../../helpers/utils';
+import { triggerHarvestAsync } from '../../backends/harvest';
 import type { LicenseMap, LicenseInfo } from '../../document';
 
 interface LockfileDepsInfo {
@@ -74,12 +75,16 @@ export class Yarn3DependencyProcessor {
         this.allDependencies.set(pkg, this.extractLicenseInfo(pkg));
       });
 
+      const harvestFn = options?.harvest
+        ? (ids: string[]) => triggerHarvestAsync(ids, 5000)
+        : undefined;
+
       PackageManagerUtils.processAndGenerateDocuments(
         prodDeps,
         devDeps,
         this.allDependencies,
         this.paths,
-        options
+        { ...options, harvestFn },
       );
     } catch (error) {
       const msg = error instanceof Error ? error.message : 'Unknown error';

--- a/src/package-managers/yarn3/yarn3-processor.ts
+++ b/src/package-managers/yarn3/yarn3-processor.ts
@@ -112,7 +112,6 @@ export class Yarn3Processor extends PackageManagerBase {
         batchSize: parseInt(this.env.BATCH_SIZE),
         outputFile: depsFilePath,
         debug: this.options.debug,
-        enableHarvest: this.options.harvest,
         ...(this.options.postTimeoutMs !== undefined ? { postTimeoutMs: this.options.postTimeoutMs } : {}),
         ...(this.options.getTimeoutMs !== undefined ? { getTimeoutMs: this.options.getTimeoutMs } : {}),
         ...(cachedResolutions ? { cachedResolutions } : {}),

--- a/src/package-managers/yarn3/yarn3-processor.ts
+++ b/src/package-managers/yarn3/yarn3-processor.ts
@@ -125,7 +125,7 @@ export class Yarn3Processor extends PackageManagerBase {
         outputFile: depsFilePath,
         debug: this.options.debug,
         prodIdentifiers: new Set(lockfileResult.prod),
-        devIdentifiers: new Set(lockfileResult.dev),
+        devIdentifiers: new Set(devDependencies),
         ...(this.options.postTimeoutMs !== undefined ? { postTimeoutMs: this.options.postTimeoutMs } : {}),
         ...(this.options.getTimeoutMs !== undefined ? { getTimeoutMs: this.options.getTimeoutMs } : {}),
         ...(cachedResolutions ? { cachedResolutions } : {}),
@@ -147,7 +147,9 @@ export class Yarn3Processor extends PackageManagerBase {
     console.log('Checking dependencies for restrictions to use...');
     try {
       const processor = new Yarn3DependencyProcessor();
-      processor.process({ harvest: this.options.harvest, check: this.options.check });
+      const procOpts: import('../../helpers/utils').ProcessingOptions = { harvest: this.options.harvest, check: this.options.check };
+      if (this.options.getTimeoutMs !== undefined) procOpts.getTimeoutMs = this.options.getTimeoutMs;
+      processor.process(procOpts);
       return 0;
     } catch (error) {
       // Error already logged by the processor

--- a/src/package-managers/yarn3/yarn3-processor.ts
+++ b/src/package-managers/yarn3/yarn3-processor.ts
@@ -80,13 +80,25 @@ export class Yarn3Processor extends PackageManagerBase {
     console.log('Done.');
     console.log();
 
-    // 3. Write dep lists for bump-deps (lockfile format)
+    // 3. Write dep lists for bump-deps (lockfile format).
+    // Some deps appear in lockfileResult.all but in neither .prod nor .dev
+    // (transitive deps of optional packages or graph-traversal gaps). Classify
+    // them as dev so they are written to dev.md and picked up by the cache on
+    // subsequent runs — otherwise they would be re-queried from ClearlyDefined
+    // on every run without ever being persisted.
+    const prodSet = new Set(lockfileResult.prod);
+    const devSet = new Set(lockfileResult.dev);
+    const uncategorized = lockfileResult.all.filter(d => !prodSet.has(d) && !devSet.has(d));
+    const devDependencies = uncategorized.length > 0
+      ? [...lockfileResult.dev, ...uncategorized]
+      : lockfileResult.dev;
+
     const depsInfoPath = path.join(this.env.TMP_DIR, 'yarn3-deps-info.json');
     writeFileSync(
       depsInfoPath,
       JSON.stringify({
         dependencies: lockfileResult.prod,
-        devDependencies: lockfileResult.dev
+        devDependencies,
       }),
       'utf8'
     );

--- a/src/package-managers/yarn3/yarn3-processor.ts
+++ b/src/package-managers/yarn3/yarn3-processor.ts
@@ -113,6 +113,8 @@ export class Yarn3Processor extends PackageManagerBase {
         outputFile: depsFilePath,
         debug: this.options.debug,
         enableHarvest: this.options.harvest,
+        ...(this.options.postTimeoutMs !== undefined ? { postTimeoutMs: this.options.postTimeoutMs } : {}),
+        ...(this.options.getTimeoutMs !== undefined ? { getTimeoutMs: this.options.getTimeoutMs } : {}),
         ...(cachedResolutions ? { cachedResolutions } : {}),
       });
       await processor.process();

--- a/src/package-managers/yarn3/yarn3-processor.ts
+++ b/src/package-managers/yarn3/yarn3-processor.ts
@@ -19,6 +19,7 @@ import { parseYarnLockfile } from './yarn-lockfile';
 import { Yarn3DependencyProcessor } from './bump-deps';
 import type { Environment, Options } from '../../helpers/types';
 import { environmentToProcessEnv } from '../../helpers/types';
+import { loadResolvedCache } from '../../helpers/utils';
 
 /**
  * Yarn 3+ package manager processor.
@@ -97,6 +98,13 @@ export class Yarn3Processor extends PackageManagerBase {
     console.log(`Generating DEPENDENCIES file (batch size: ${this.env.BATCH_SIZE})...`);
     const depsFilePath = path.join(this.env.TMP_DIR, 'DEPENDENCIES');
     try {
+      const cachedResolutions = this.options.recheck
+        ? undefined
+        : loadResolvedCache(
+            path.join(this.env.DEPS_DIR, 'prod.md'),
+            path.join(this.env.DEPS_DIR, 'dev.md'),
+          );
+
       const processor = new ChunkedDashLicensesProcessor({
         parserScript: 'cat',
         parserInput: allDepsFile,
@@ -104,7 +112,8 @@ export class Yarn3Processor extends PackageManagerBase {
         batchSize: parseInt(this.env.BATCH_SIZE),
         outputFile: depsFilePath,
         debug: this.options.debug,
-        enableHarvest: this.options.harvest
+        enableHarvest: this.options.harvest,
+        ...(cachedResolutions ? { cachedResolutions } : {}),
       });
       await processor.process();
     } catch (error: unknown) {

--- a/src/package-managers/yarn3/yarn3-processor.ts
+++ b/src/package-managers/yarn3/yarn3-processor.ts
@@ -112,6 +112,8 @@ export class Yarn3Processor extends PackageManagerBase {
         batchSize: parseInt(this.env.BATCH_SIZE),
         outputFile: depsFilePath,
         debug: this.options.debug,
+        prodIdentifiers: new Set(lockfileResult.prod),
+        devIdentifiers: new Set(lockfileResult.dev),
         ...(this.options.postTimeoutMs !== undefined ? { postTimeoutMs: this.options.postTimeoutMs } : {}),
         ...(this.options.getTimeoutMs !== undefined ? { getTimeoutMs: this.options.getTimeoutMs } : {}),
         ...(cachedResolutions ? { cachedResolutions } : {}),


### PR DESCRIPTION
### What does this PR do?

Several related improvements to how the tool queries and caches ClearlyDefined license data, plus automatic cleanup of stale EXCLUDED file entries.

#### 1. Dependency cache (skip already-resolved deps)

On each run the tool now reads `.deps/prod.md` and `.deps/dev.md` before calling ClearlyDefined. Any dependency whose **Resolved CQs** column is non-empty (a `clearlydefined` link or CQ number) is considered already resolved and is skipped — only new or previously unresolved dependencies are sent to the API.

Result on `eclipse-che/che-dashboard` (~1 421 total dependencies):
- **Before**: every dep queried on every run
- **After**: ~93 API queries (1 328 served from cache)

`--recheck` bypasses the cache and re-queries everything.

Key implementation details:
- `loadResolvedCache(prodMdPath, devMdPath)` reads both files, stores `{license, cq}` per identifier.
- `coordinateToIdentifier()` handles all three coordinate formats: plain `pkg@version`, Yarn Berry `pkg@npm:version`, and ClearlyDefined `npm/npmjs/…`.
- Cached entries are reconstructed in proper ClearlyDefined DEPENDENCIES format (`npm/npmjs/…, MIT, approved, clearlydefined`) so `parseDependenciesFile` can process them correctly.
- "transitive dependency" placeholder entries are excluded from the cache.
- Entries in linked-name format (`` [`pkg@version`](url) ``) are matched by an updated regex.
- Entries with an empty license column (deps sourced from EXCLUDED files, e.g. `| dep |  | ecd.che |`) are now matched correctly (`([^|]*)` instead of `([^|]+)`).

#### 2. Enriched cache-miss log

The cache-miss message now breaks down the misses by type:

```text
Cache miss: 93 dependencies to query (38 version bumps, 55 new packages).
```

- **prod / dev / prod+dev** — which dep bucket(s) (available for npm and yarn3)
- **version bumps** — package name was cached at a different version (expected after `yarn.lock` upgrades)
- **new packages** — package name not seen in the cache at all

#### 3. Configurable POST/GET timeouts

Realistic defaults; overridable via CLI or `LibraryConfig`:

| Request type | Old default | New default | CLI flag |
|---|---|---|---|
| Batch POST `/definitions` | 60 000 ms | **30 000 ms** | `--post-timeout <ms>` |
| Individual GET `/definitions/{id}` | 30 000 ms | **5 000 ms** | `--get-timeout <ms>` |

The batch POST is retried once (after 2 s) before falling back to individual GETs.

#### 4. Harvest only direct-unresolved dependencies

Previously harvest was triggered for every dep returned as `notfound` by the API — including transitive dependencies that are automatically added to `.deps/EXCLUDED/`. Transitive deps are not owned by the project and should not be harvested.

The transitive/direct split happens inside `processAndGenerateDocuments()`, which runs after the API call. Harvest now runs there too:

- `src/backends/harvest.ts` (new) — standalone `triggerHarvestAsync(identifiers, getTimeoutMs)` with two phases: await GET checks, then fire POST requests (fire-and-forget).
- `processAndGenerateDocuments()` receives an optional `harvestFn` callback called with **only the direct unresolved identifiers** (those that end up in `problems.md`). Transitive deps are excluded.
- `ClearlyDefinedBackend` no longer owns harvest logic (`enableHarvest` option and `processHarvest()` method removed).

#### 5. Persistent cache misses eliminated

Previously, certain deps were re-queried from ClearlyDefined on **every** run even though yarn.lock hadn't changed. Three root causes were found and fixed:

**Root cause A — uncategorized yarn3 deps never written to output files:**
The yarn3 lockfile parser produces `prod`, `dev`, and `all` arrays. 93 deps appeared in `all` (queried by the API and approved) but in neither `prod` nor `dev` (graph-traversal gaps for optional/transitive packages). Since `arrayToDocument` only writes deps from `prodDeps`/`devDeps`, these deps were approved but never stored in `prod.md`/`dev.md`, so never cached. Fix: uncategorized deps are appended to `devDependencies` in `yarn3-deps-info.json`.

**Root cause B — transitive deps written to EXCLUDED only with --harvest:**
The `appendTransitiveExcludes` call was gated on `--harvest`. Without that flag, transitive version-bumped deps were printed to the console but never persisted. Fix: always write transitive deps to EXCLUDED in generate mode.

**Root cause C — EXCLUDED files not read by loadResolvedCache:**
Even after Root cause B was fixed, transitive deps in EXCLUDED would still be re-queried because `loadResolvedCache` only read `prod.md`/`dev.md`. Fix: also read `EXCLUDED/prod.md` and `EXCLUDED/dev.md`; cache these entries with empty license so the chunked processor writes them as `restricted, excluded` instead of querying the API.

#### 6. EXCLUDED auto-cleanup

EXCLUDED files can accumulate stale entries over time (entries that were once unresolved or transitive but are now approved by ClearlyDefined). Two complementary mechanisms keep them clean:

**Per-run inline verification (every run):**
EXCLUDED entries whose CQ is a `[clearlydefined](…)` link and that appear in the current dependency list are sent to the ClearlyDefined batch API on every run. If the API confirms them as approved, `parseDependenciesFile` detects them as "unused excludes" and `processAndGenerateDocuments` removes them from the EXCLUDED file in the same run.

**Full recheck with `--harvest`:**
When `--harvest` is passed, `recheckAndCleanExcluded` (new: `src/helpers/recheck-excluded.ts`) re-queries every entry in `EXCLUDED/prod.md` and `EXCLUDED/dev.md` against ClearlyDefined — including orphans no longer in yarn.lock and entries with `transitive dependency` CQ. Any entry confirmed as approved is removed immediately.

### What issues does this PR fix or reference?

fixes https://github.com/eclipse-che/che/issues/23896